### PR TITLE
Implement Copy-to-Clipboard for Transaction Hashes

### DIFF
--- a/src/components/CopyButton.js
+++ b/src/components/CopyButton.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+const CopyButton = ({ text, className = '' }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!text) return;
+    
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`relative inline-flex items-center justify-center p-1 rounded-md text-gray-400 hover:text-purple-600 hover:bg-purple-50 transition-colors group ${className}`}
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+      
+      {/* Tooltip */}
+      <span className={`absolute -top-8 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-gray-900 text-white text-xs rounded shadow-sm transition-opacity duration-200 pointer-events-none whitespace-nowrap ${copied ? 'opacity-100' : 'opacity-0'}`}>
+        Copied!
+        <span className="absolute top-full left-1/2 transform -translate-x-1/2 -mt-px border-4 border-transparent border-t-gray-900"></span>
+      </span>
+    </button>
+  );
+};
+
+export default CopyButton;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Menu, Wallet, X, LogOut } from 'lucide-react';
 import { Button, Badge, Avatar } from './ui';
+import CopyButton from './CopyButton';
 
 const Header = ({ onMenuClick, onConnectWallet, onDisconnectWallet, address, isConnected }) => {
   return (
@@ -52,9 +53,12 @@ const Header = ({ onMenuClick, onConnectWallet, onDisconnectWallet, address, isC
                 />
                 <div className="flex flex-col pr-2">
                   <p className="text-[10px] sm:text-xs text-gray-500 font-medium leading-tight">Connected</p>
-                  <p className="text-xs sm:text-sm font-mono font-bold text-gray-900 leading-tight">
-                    {address.slice(0, 4)}...{address.slice(-4)}
-                  </p>
+                  <div className="flex items-center gap-1 group/address">
+                    <p className="text-xs sm:text-sm font-mono font-bold text-gray-900 leading-tight">
+                      {address.slice(0, 4)}...{address.slice(-4)}
+                    </p>
+                    <CopyButton text={address} className="opacity-0 group-hover/address:opacity-100 transition-opacity -my-1 -ml-1" />
+                  </div>
                 </div>
                 <Button
                   variant="ghost"

--- a/src/components/TransactionHistory.js
+++ b/src/components/TransactionHistory.js
@@ -15,6 +15,7 @@ import {
 import { useMuseStore } from '../store/museStore';
 import { useWalletStore } from '../store/walletStore';
 import toast from 'react-hot-toast';
+import CopyButton from './CopyButton';
 
 const TransactionHistory = () => {
   const { userAddress, fetchWutaWutaTransactions } = useMuseStore();
@@ -330,8 +331,11 @@ const TransactionHistory = () => {
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900 font-mono">
-                        {tx.hash.slice(0, 8)}...{tx.hash.slice(-8)}
+                      <div className="flex items-center gap-2">
+                        <div className="text-sm text-gray-900 font-mono">
+                          {tx.hash.slice(0, 8)}...{tx.hash.slice(-8)}
+                        </div>
+                        <CopyButton text={tx.hash} />
                       </div>
                       {tx.memo && (
                         <div className="text-xs text-gray-500 mt-1">Memo: {tx.memo}</div>

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -17,6 +17,7 @@ import { useMuseStore } from '../store/museStore';
 import { useWalletStore } from '../store/walletStore';
 import { useUserProfileStore } from '../store/userProfileStore';
 import ArtworkGrid from './ArtworkGrid';
+import CopyButton from './CopyButton';
 
 const UserProfile = () => {
   const { listings } = useMuseStore();
@@ -96,9 +97,12 @@ const UserProfile = () => {
                 {profile.username || 'Creator Profile'}
               </h1>
               <div className="flex items-center mt-1 sm:mt-2 space-x-3">
-                <p className="text-gray-500 font-mono text-xs sm:text-sm bg-gray-50 px-3 py-1 rounded-full border border-gray-100">
-                  {address?.slice(0, 6)}...{address?.slice(-4)}
-                </p>
+                <div className="flex items-center bg-gray-50 px-3 py-1 rounded-full border border-gray-100 group gap-1">
+                  <p className="text-gray-500 font-mono text-xs sm:text-sm">
+                    {address?.slice(0, 6)}...{address?.slice(-4)}
+                  </p>
+                  <CopyButton text={address} className="opacity-0 group-hover:opacity-100 transition-opacity -my-1" />
+                </div>
                 {profile.verification?.isVerified && (
                   <div className="flex items-center space-x-1.5 bg-yellow-50 px-2.5 py-1 rounded-full border border-yellow-100">
                     <Award className="w-3.5 h-3.5 text-yellow-600" />
@@ -291,11 +295,19 @@ const UserProfile = () => {
                       </p>
 
                       <div className="flex justify-between items-end mt-2">
-                        <p className="text-[10px] sm:text-xs text-gray-500 font-medium">
-                          {transaction.type === 'sale' ? `To: ${transaction.buyer?.slice(0, 4)}...${transaction.buyer?.slice(-4)}` :
-                           transaction.type === 'purchase' ? `From: ${transaction.seller?.slice(0, 4)}...${transaction.seller?.slice(-4)}` :
-                           `Listed by you`}
-                        </p>
+                        <div className="flex items-center gap-1 group/address">
+                          <p className="text-[10px] sm:text-xs text-gray-500 font-medium">
+                            {transaction.type === 'sale' ? `To: ${transaction.buyer?.slice(0, 4)}...${transaction.buyer?.slice(-4)}` :
+                             transaction.type === 'purchase' ? `From: ${transaction.seller?.slice(0, 4)}...${transaction.seller?.slice(-4)}` :
+                             `Listed by you`}
+                          </p>
+                          {(transaction.type === 'sale' && transaction.buyer) && (
+                            <CopyButton text={transaction.buyer} className="opacity-0 group-hover/address:opacity-100 transition-opacity" />
+                          )}
+                          {(transaction.type === 'purchase' && transaction.seller) && (
+                            <CopyButton text={transaction.seller} className="opacity-0 group-hover/address:opacity-100 transition-opacity" />
+                          )}
+                        </div>
                         <p className="text-[10px] text-gray-400">
                           {formatDate(transaction.timestamp).split(',')[0]}
                         </p>


### PR DESCRIPTION
Closes #23

---

I have successfully implemented the "Copy-to-Clipboard" functionality for Stellar addresses and Transaction Hashes as requested.

Here is what I've done:

Created a reusable CopyButton component that includes the "Copy" icon (lucide-react) and handles the clipboard writing as well as a temporary "Copied!" tooltip overlay.
Updated TransactionHistory.js to add the copy icon next to transaction hashes.
Updated UserProfile.js to add the copy icon next to the user's Stellar address in the profile header, and next to buyer/seller addresses in their trading history overview.
Updated Header.js to include the copy icon next to the connected wallet address snippet on the top navigation bar.
All addresses are now easily copyable with a single click, providing immediate visual feedback ("Copied!") via the sleek tooltip.

