### PR TITLE
Implement "Infinite Scroll" for Art Gallery

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useInfiniteScroll } from '../utils/useInfiniteScroll';
 import { motion } from 'framer-motion';
 import { 
   Gallery as GalleryIcon, 
@@ -69,6 +70,8 @@ const Gallery = () => {
     }
   });
   
+  const { visibleItems, hasMore, sentinelRef } = useInfiniteScroll(sortedArtworks);
+
   const handleBuyArtwork = async (tokenId, price) => {
     if (!address) {
       toast.error('Please connect your wallet first');
@@ -229,12 +232,19 @@ const Gallery = () => {
 
       {/* Gallery Grid using responsive component */}
       <ArtworkGrid 
-        artworks={sortedArtworks} 
+        artworks={visibleItems} 
         listings={listings} 
         onBuyArtwork={handleBuyArtwork} 
         isLoading={isLoading} 
         address={address} 
       />
+
+      {/* Infinite scroll sentinel */}
+      {hasMore && (
+        <div ref={sentinelRef} className="flex justify-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-purple-500 border-t-transparent" />
+        </div>
+      )}
       
       {/* Empty State */}
       {sortedArtworks.length === 0 && (

--- a/src/utils/useInfiniteScroll.js
+++ b/src/utils/useInfiniteScroll.js
@@ -1,0 +1,35 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const PAGE_SIZE = 12;
+
+export function useInfiniteScroll(items) {
+  const [page, setPage] = useState(1);
+  const sentinelRef = useRef(null);
+
+  // Reset to page 1 whenever the source list changes (filter/sort)
+  useEffect(() => {
+    setPage(1);
+  }, [items]);
+
+  const loadMore = useCallback(() => {
+    setPage((p) => p + 1);
+  }, []);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { rootMargin: '200px' }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  const visibleItems = items.slice(0, page * PAGE_SIZE);
+  const hasMore = visibleItems.length < items.length;
+
+  return { visibleItems, hasMore, sentinelRef };
+}


### PR DESCRIPTION
## 🚀 feat: Add Infinite Scroll to AI Art Gallery

### Summary

Replaces full rendering of `sortedArtworks` with an **IntersectionObserver-based infinite scroll**, improving performance and reducing initial load time.

### Changes

* Added `useInfiniteScroll` hook to paginate artworks (12 per batch)
* Loads more items automatically when scrolling near the bottom
* Resets pagination on filter/sort changes
* Updated `Gallery` to render `visibleItems` instead of full list
* Added sentinel loader element to trigger loading

### Behavior

* Initial load shows 12 artworks
* More load automatically on scroll
* Resets on filter/sort updates
* Loader disappears when all items are loaded

### Testing

* Verify scroll loads more items
* Confirm reset on filter/sort
* Check empty state still works
* Ensure no regression in purchase flow

### Notes

* No new dependencies
* Improves performance and reduces DOM size

closed #29