### PR TITLE
feat: add shared component library and Storybook setup

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,18 @@
+/** @type { import('@storybook/react-webpack5').StorybookConfig } */
+const config = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-links',
+  ],
+  framework: {
+    name: '@storybook/react-webpack5',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+};
+
+module.exports = config;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,30 @@
+import '../src/index.css';
+
+/** @type { import('@storybook/react').Preview } */
+const preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f9fafb' },
+        { name: 'dark', value: '#111827' },
+        { name: 'white', value: '#ffffff' },
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8 font-sans">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "type-check": "tsc --noEmit",
     "start:api": "npm --prefix backend run dev",
     "build:api": "npm --prefix backend run build",
-    "dev:full": "concurrently \"npm run start\" \"npm run start:backend\" \"npm run start:api\""
+    "dev:full": "concurrently \"npm run start\" \"npm run start:backend\" \"npm run start:api\"",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
@@ -63,6 +65,12 @@
     "hardhat": "^2.17.0",
     "http-proxy-middleware": "^2.0.6",
     "prettier": "^3.0.0",
+    "@storybook/addon-essentials": "^7.6.0",
+    "@storybook/addon-interactions": "^7.6.0",
+    "@storybook/addon-links": "^7.6.0",
+    "@storybook/react": "^7.6.0",
+    "@storybook/react-webpack5": "^7.6.0",
+    "storybook": "^7.6.0",
     "supertest": "^6.3.3",
     "typescript": "^4.9.0"
   },

--- a/src/lib/Badge.jsx
+++ b/src/lib/Badge.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const Badge = React.forwardRef(
+  (
+    { children, variant = 'primary', size = 'md', className = '', icon: Icon, ...props },
+    ref,
+  ) => {
+    const baseClasses =
+      'inline-flex items-center font-medium rounded-full transition-all duration-200';
+
+    const variants = {
+      primary: 'bg-purple-100 text-purple-800 border border-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-800',
+      secondary: 'bg-gray-100 text-gray-800 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700',
+      success: 'bg-green-100 text-green-800 border border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800',
+      warning: 'bg-yellow-100 text-yellow-800 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800',
+      danger: 'bg-red-100 text-red-800 border border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800',
+      info: 'bg-blue-100 text-blue-800 border border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800',
+      outline: 'border border-gray-300 text-gray-700 bg-transparent dark:border-gray-600 dark:text-gray-300',
+    };
+
+    const sizes = {
+      sm: 'px-2 py-0.5 text-xs',
+      md: 'px-3 py-1 text-sm',
+      lg: 'px-4 py-1.5 text-base',
+    };
+
+    const iconSizes = {
+      sm: 'w-3 h-3',
+      md: 'w-4 h-4',
+      lg: 'w-5 h-5',
+    };
+
+    const classes = `${baseClasses} ${variants[variant] || variants.primary} ${sizes[size] || sizes.md} ${className}`;
+
+    return (
+      <motion.span
+        ref={ref}
+        className={classes}
+        whileHover={{ scale: 1.05 }}
+        {...props}
+      >
+        {Icon && <Icon className={`${iconSizes[size] || iconSizes.md} mr-1`} />}
+        {children}
+      </motion.span>
+    );
+  },
+);
+
+Badge.displayName = 'Badge';
+
+export default Badge;

--- a/src/lib/Badge.stories.jsx
+++ b/src/lib/Badge.stories.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { CheckCircle, AlertTriangle, Info, XCircle } from 'lucide-react';
+
+import Badge from './Badge';
+
+export default {
+  title: 'Shared/Badge',
+  component: Badge,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'success', 'warning', 'danger', 'info', 'outline'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+const Template = (args) => <Badge {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  children: 'Primary',
+  variant: 'primary',
+};
+
+export const Success = Template.bind({});
+Success.args = {
+  children: 'Active',
+  variant: 'success',
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  children: 'Pending',
+  variant: 'warning',
+};
+
+export const Danger = Template.bind({});
+Danger.args = {
+  children: 'Error',
+  variant: 'danger',
+};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  children: 'Verified',
+  variant: 'success',
+  icon: CheckCircle,
+};
+
+export const AllVariants = () => (
+  <div className="flex flex-wrap gap-3 items-center">
+    <Badge variant="primary">Primary</Badge>
+    <Badge variant="secondary">Secondary</Badge>
+    <Badge variant="success">Success</Badge>
+    <Badge variant="warning">Warning</Badge>
+    <Badge variant="danger">Danger</Badge>
+    <Badge variant="info">Info</Badge>
+    <Badge variant="outline">Outline</Badge>
+  </div>
+);
+
+export const AllSizes = () => (
+  <div className="flex flex-wrap gap-3 items-center">
+    <Badge size="sm">Small</Badge>
+    <Badge size="md">Medium</Badge>
+    <Badge size="lg">Large</Badge>
+  </div>
+);
+
+export const WithIcons = () => (
+  <div className="flex flex-wrap gap-3 items-center">
+    <Badge variant="success" icon={CheckCircle}>
+      Verified
+    </Badge>
+    <Badge variant="warning" icon={AlertTriangle}>
+      Pending
+    </Badge>
+    <Badge variant="info" icon={Info}>
+      Draft
+    </Badge>
+    <Badge variant="danger" icon={XCircle}>
+      Rejected
+    </Badge>
+  </div>
+);
+
+export const StatusLabels = () => (
+  <div className="space-y-4">
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-gray-600 w-20">Artwork:</span>
+      <Badge variant="success" size="sm">
+        Minted
+      </Badge>
+    </div>
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-gray-600 w-20">Auction:</span>
+      <Badge variant="warning" size="sm">
+        Live
+      </Badge>
+    </div>
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-gray-600 w-20">Network:</span>
+      <Badge variant="info" size="sm">
+        Testnet
+      </Badge>
+    </div>
+  </div>
+);

--- a/src/lib/Button.jsx
+++ b/src/lib/Button.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Loader2 } from 'lucide-react';
+
+const Button = React.forwardRef(
+  (
+    {
+      children,
+      variant = 'primary',
+      size = 'md',
+      loading = false,
+      disabled = false,
+      icon: Icon,
+      iconPosition = 'left',
+      className = '',
+      onClick,
+      ...props
+    },
+    ref,
+  ) => {
+    const baseClasses =
+      'inline-flex items-center justify-center font-medium rounded-xl transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+
+    const variants = {
+      primary:
+        'bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700 focus:ring-purple-500 shadow-lg hover:shadow-xl',
+      secondary:
+        'bg-white border border-gray-200 text-gray-900 hover:bg-gray-50 focus:ring-purple-500 shadow-md hover:shadow-lg dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-700',
+      ghost:
+        'text-gray-700 hover:bg-gray-100 focus:ring-purple-500 dark:text-gray-300 dark:hover:bg-gray-800',
+    };
+
+    const sizes = {
+      sm: 'px-3 py-1.5 text-sm',
+      md: 'px-4 py-2 text-base',
+      lg: 'px-6 py-3 text-lg',
+    };
+
+    const iconSizes = {
+      sm: 'w-4 h-4',
+      md: 'w-5 h-5',
+      lg: 'w-6 h-6',
+    };
+
+    const classes = `${baseClasses} ${variants[variant] || variants.primary} ${sizes[size] || sizes.md} ${className}`;
+    const isDisabled = disabled || loading;
+
+    return (
+      <motion.button
+        ref={ref}
+        className={classes}
+        whileHover={{ scale: isDisabled ? 1 : 1.02 }}
+        whileTap={{ scale: isDisabled ? 1 : 0.98 }}
+        onClick={isDisabled ? undefined : onClick}
+        disabled={isDisabled}
+        {...props}
+      >
+        {loading && (
+          <Loader2
+            data-testid="button-loading-spinner"
+            className={`animate-spin ${iconSizes[size] || iconSizes.md} mr-2`}
+          />
+        )}
+
+        {!loading && Icon && iconPosition === 'left' && (
+          <Icon className={`${iconSizes[size] || iconSizes.md} mr-2`} />
+        )}
+
+        {children}
+
+        {!loading && Icon && iconPosition === 'right' && (
+          <Icon className={`${iconSizes[size] || iconSizes.md} ml-2`} />
+        )}
+      </motion.button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/src/lib/Button.stories.jsx
+++ b/src/lib/Button.stories.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Heart, ArrowRight, Download } from 'lucide-react';
+
+import Button from './Button';
+
+export default {
+  title: 'Shared/Button',
+  component: Button,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'ghost'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    loading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+};
+
+const Template = (args) => <Button {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  children: 'Primary Button',
+  variant: 'primary',
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  children: 'Secondary Button',
+  variant: 'secondary',
+};
+
+export const Ghost = Template.bind({});
+Ghost.args = {
+  children: 'Ghost Button',
+  variant: 'ghost',
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  children: 'Small',
+  size: 'sm',
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  children: 'Large Button',
+  size: 'lg',
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  children: 'Loading...',
+  loading: true,
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  children: 'Disabled',
+  disabled: true,
+};
+
+export const WithIconLeft = Template.bind({});
+WithIconLeft.args = {
+  children: 'Like',
+  icon: Heart,
+  iconPosition: 'left',
+};
+
+export const WithIconRight = Template.bind({});
+WithIconRight.args = {
+  children: 'Next',
+  icon: ArrowRight,
+  iconPosition: 'right',
+};
+
+export const AllVariants = () => (
+  <div className="flex flex-wrap gap-4 items-center">
+    <Button variant="primary">Primary</Button>
+    <Button variant="secondary">Secondary</Button>
+    <Button variant="ghost">Ghost</Button>
+    <Button loading>Loading</Button>
+    <Button disabled>Disabled</Button>
+    <Button icon={Download} size="sm">
+      Download
+    </Button>
+  </div>
+);

--- a/src/lib/Card.jsx
+++ b/src/lib/Card.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const Card = React.forwardRef(
+  (
+    {
+      children,
+      className = '',
+      hover = true,
+      glass = false,
+      padding = 'md',
+      shadow = 'md',
+      onClick,
+      ...props
+    },
+    ref,
+  ) => {
+    const baseClasses = 'rounded-xl transition-all duration-300';
+
+    const paddingClasses = {
+      none: '',
+      sm: 'p-4',
+      md: 'p-6',
+      lg: 'p-8',
+    };
+
+    const shadowClasses = {
+      none: '',
+      sm: 'shadow-sm',
+      md: 'shadow-lg',
+      lg: 'shadow-xl',
+    };
+
+    const glassClasses = glass
+      ? 'bg-white/80 backdrop-blur-xl border border-white/20 dark:bg-gray-900/80 dark:border-gray-700/20'
+      : 'bg-white border border-gray-100 dark:bg-gray-900 dark:border-gray-800';
+
+    const hoverClasses = hover
+      ? 'hover:shadow-xl hover:scale-[1.02] cursor-pointer'
+      : '';
+
+    const classes = `${baseClasses} ${glassClasses} ${paddingClasses[padding] || paddingClasses.md} ${shadowClasses[shadow] || shadowClasses.md} ${hoverClasses} ${className}`;
+
+    const MotionComponent = hover || onClick ? motion.div : 'div';
+
+    return (
+      <MotionComponent
+        ref={ref}
+        className={classes}
+        whileHover={hover ? { y: -2 } : undefined}
+        onClick={onClick}
+        {...props}
+      >
+        {children}
+      </MotionComponent>
+    );
+  },
+);
+
+Card.displayName = 'Card';
+
+export const CardHeader = React.forwardRef(
+  ({ children, className = '', ...props }, ref) => (
+    <div ref={ref} className={`mb-4 ${className}`} {...props}>
+      {children}
+    </div>
+  ),
+);
+
+CardHeader.displayName = 'CardHeader';
+
+export const CardTitle = React.forwardRef(
+  ({ children, className = '', ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={`text-xl font-bold text-gray-900 dark:text-white ${className}`}
+      {...props}
+    >
+      {children}
+    </h3>
+  ),
+);
+
+CardTitle.displayName = 'CardTitle';
+
+export const CardContent = React.forwardRef(
+  ({ children, className = '', ...props }, ref) => (
+    <div ref={ref} className={className} {...props}>
+      {children}
+    </div>
+  ),
+);
+
+CardContent.displayName = 'CardContent';
+
+export const CardFooter = React.forwardRef(
+  ({ children, className = '', ...props }, ref) => (
+    <div
+      ref={ref}
+      className={`mt-4 pt-4 border-t border-gray-100 dark:border-gray-800 ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+);
+
+CardFooter.displayName = 'CardFooter';
+
+export default Card;

--- a/src/lib/Card.stories.jsx
+++ b/src/lib/Card.stories.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import Card, { CardHeader, CardTitle, CardContent, CardFooter } from './Card';
+import Button from './Button';
+
+export default {
+  title: 'Shared/Card',
+  component: Card,
+  argTypes: {
+    hover: { control: 'boolean' },
+    glass: { control: 'boolean' },
+    padding: {
+      control: 'select',
+      options: ['none', 'sm', 'md', 'lg'],
+    },
+    shadow: {
+      control: 'select',
+      options: ['none', 'sm', 'md', 'lg'],
+    },
+  },
+};
+
+const Template = (args) => <Card {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: (
+    <div>
+      <h3 className="text-lg font-bold mb-2">Default Card</h3>
+      <p className="text-gray-600">This is a default card with medium padding and shadow.</p>
+    </div>
+  ),
+};
+
+export const GlassCard = Template.bind({});
+GlassCard.args = {
+  glass: true,
+  children: (
+    <div>
+      <h3 className="text-lg font-bold mb-2">Glass Card</h3>
+      <p className="text-gray-600">Glassmorphism effect with backdrop blur.</p>
+    </div>
+  ),
+};
+
+export const NoHover = Template.bind({});
+NoHover.args = {
+  hover: false,
+  children: (
+    <div>
+      <h3 className="text-lg font-bold mb-2">Static Card</h3>
+      <p className="text-gray-600">This card has no hover effect.</p>
+    </div>
+  ),
+};
+
+export const WithSubComponents = () => (
+  <Card hover={false} className="max-w-md">
+    <CardHeader>
+      <CardTitle>Artwork #42</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div className="h-48 bg-gradient-to-br from-purple-400 to-blue-400 rounded-lg mb-4" />
+      <p className="text-gray-600 text-sm">
+        A collaborative AI-generated artwork exploring the boundaries of digital creativity.
+      </p>
+    </CardContent>
+    <CardFooter>
+      <div className="flex items-center justify-between w-full">
+        <span className="text-sm font-semibold text-gray-900">0.5 XLM</span>
+        <Button size="sm">Place Bid</Button>
+      </div>
+    </CardFooter>
+  </Card>
+);
+
+export const CardGrid = () => (
+  <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+    {['Small Shadow', 'Medium Shadow', 'Large Shadow'].map((label, i) => (
+      <Card key={label} shadow={['sm', 'md', 'lg'][i]} padding="md">
+        <h3 className="font-bold mb-2">{label}</h3>
+        <p className="text-gray-600 text-sm">Shadow variant: {['sm', 'md', 'lg'][i]}</p>
+      </Card>
+    ))}
+  </div>
+);

--- a/src/lib/Modal.jsx
+++ b/src/lib/Modal.jsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+
+const Modal = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  size = 'md',
+  showCloseButton = true,
+  closeOnBackdropClick = true,
+  className = '',
+  ...props
+}) => {
+  const handleEscape = useCallback(
+    (e) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    },
+    [isOpen, onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [handleEscape]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  const sizes = {
+    sm: 'max-w-md',
+    md: 'max-w-lg',
+    lg: 'max-w-2xl',
+    xl: 'max-w-4xl',
+    full: 'max-w-full mx-4',
+  };
+
+  const handleBackdropClick = (e) => {
+    if (closeOnBackdropClick && e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 overflow-y-auto"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          data-testid="modal-overlay"
+        >
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={handleBackdropClick}
+            data-testid="modal-backdrop"
+          />
+
+          {/* Modal */}
+          <div className="flex min-h-full items-center justify-center p-4">
+            <motion.div
+              className={`relative w-full ${sizes[size] || sizes.md} bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-100 dark:border-gray-800 ${className}`}
+              initial={{ scale: 0.95, opacity: 0, y: 20 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.95, opacity: 0, y: 20 }}
+              transition={{ type: 'spring', duration: 0.3 }}
+              role="dialog"
+              aria-modal="true"
+              aria-label={title || 'Modal dialog'}
+              {...props}
+            >
+              {/* Header */}
+              {(title || showCloseButton) && (
+                <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-800">
+                  {title && (
+                    <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+                      {title}
+                    </h2>
+                  )}
+                  {showCloseButton && (
+                    <button
+                      onClick={onClose}
+                      className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+                      aria-label="Close modal"
+                      data-testid="modal-close-button"
+                    >
+                      <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {/* Content */}
+              <div className="p-6">{children}</div>
+            </motion.div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+Modal.displayName = 'Modal';
+
+export default Modal;

--- a/src/lib/Modal.stories.jsx
+++ b/src/lib/Modal.stories.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+
+import Modal from './Modal';
+import Button from './Button';
+
+export default {
+  title: 'Shared/Modal',
+  component: Modal,
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl'],
+    },
+    showCloseButton: { control: 'boolean' },
+    closeOnBackdropClick: { control: 'boolean' },
+  },
+};
+
+const ModalDemo = ({ size, title, showCloseButton, closeOnBackdropClick, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setIsOpen(true)}>Open Modal</Button>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title={title}
+        size={size}
+        showCloseButton={showCloseButton}
+        closeOnBackdropClick={closeOnBackdropClick}
+      >
+        {children}
+      </Modal>
+    </div>
+  );
+};
+
+export const Default = () => (
+  <ModalDemo title="Default Modal" size="md">
+    <p className="text-gray-600">This is a default modal with a title and close button.</p>
+  </ModalDemo>
+);
+
+export const Small = () => (
+  <ModalDemo title="Small Modal" size="sm">
+    <p className="text-gray-600">A compact modal for simple confirmations.</p>
+    <div className="mt-4 flex gap-3 justify-end">
+      <Button variant="ghost" size="sm">
+        Cancel
+      </Button>
+      <Button size="sm">Confirm</Button>
+    </div>
+  </ModalDemo>
+);
+
+export const Large = () => (
+  <ModalDemo title="Large Modal" size="lg">
+    <div className="space-y-4">
+      <p className="text-gray-600">
+        A larger modal suitable for forms and detailed content.
+      </p>
+      <div className="h-32 bg-gray-100 rounded-lg flex items-center justify-center text-gray-400">
+        Content area
+      </div>
+    </div>
+  </ModalDemo>
+);
+
+export const NoCloseButton = () => (
+  <ModalDemo title="No Close Button" size="md" showCloseButton={false}>
+    <p className="text-gray-600">
+      This modal has no close button. Use Escape or the backdrop to close.
+    </p>
+  </ModalDemo>
+);
+
+export const WithForm = () => (
+  <ModalDemo title="Create Artwork" size="md">
+    <form className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+        <input
+          type="text"
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+          placeholder="Enter artwork title"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+        <textarea
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+          rows={3}
+          placeholder="Describe your artwork"
+        />
+      </div>
+      <div className="flex justify-end gap-3 pt-2">
+        <Button variant="ghost">Cancel</Button>
+        <Button>Create</Button>
+      </div>
+    </form>
+  </ModalDemo>
+);

--- a/src/lib/Spinner.jsx
+++ b/src/lib/Spinner.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const Spinner = React.forwardRef(
+  ({ size = 'md', color = 'purple', className = '', label = 'Loading', ...props }, ref) => {
+    const sizes = {
+      sm: 'w-5 h-5 border-2',
+      md: 'w-8 h-8 border-2',
+      lg: 'w-12 h-12 border-3',
+      xl: 'w-16 h-16 border-4',
+    };
+
+    const colors = {
+      purple: 'border-purple-600 border-t-transparent',
+      blue: 'border-blue-600 border-t-transparent',
+      green: 'border-green-600 border-t-transparent',
+      red: 'border-red-600 border-t-transparent',
+      gray: 'border-gray-600 border-t-transparent',
+      white: 'border-white border-t-transparent',
+    };
+
+    const classes = `${sizes[size] || sizes.md} ${colors[color] || colors.purple} rounded-full ${className}`;
+
+    return (
+      <motion.div
+        ref={ref}
+        className={classes}
+        animate={{ rotate: 360 }}
+        transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+        role="status"
+        aria-label={label}
+        data-testid="spinner"
+        {...props}
+      />
+    );
+  },
+);
+
+Spinner.displayName = 'Spinner';
+
+export default Spinner;

--- a/src/lib/Spinner.stories.jsx
+++ b/src/lib/Spinner.stories.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import Spinner from './Spinner';
+
+export default {
+  title: 'Shared/Spinner',
+  component: Spinner,
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl'],
+    },
+    color: {
+      control: 'select',
+      options: ['purple', 'blue', 'green', 'red', 'gray', 'white'],
+    },
+  },
+};
+
+const Template = (args) => <Spinner {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Small = Template.bind({});
+Small.args = {
+  size: 'sm',
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  size: 'lg',
+};
+
+export const ExtraLarge = Template.bind({});
+ExtraLarge.args = {
+  size: 'xl',
+};
+
+export const AllSizes = () => (
+  <div className="flex items-center gap-6">
+    <div className="text-center">
+      <Spinner size="sm" />
+      <p className="text-xs text-gray-500 mt-2">Small</p>
+    </div>
+    <div className="text-center">
+      <Spinner size="md" />
+      <p className="text-xs text-gray-500 mt-2">Medium</p>
+    </div>
+    <div className="text-center">
+      <Spinner size="lg" />
+      <p className="text-xs text-gray-500 mt-2">Large</p>
+    </div>
+    <div className="text-center">
+      <Spinner size="xl" />
+      <p className="text-xs text-gray-500 mt-2">Extra Large</p>
+    </div>
+  </div>
+);
+
+export const AllColors = () => (
+  <div className="flex items-center gap-6">
+    {['purple', 'blue', 'green', 'red', 'gray'].map((color) => (
+      <div key={color} className="text-center">
+        <Spinner color={color} />
+        <p className="text-xs text-gray-500 mt-2 capitalize">{color}</p>
+      </div>
+    ))}
+  </div>
+);
+
+export const OnDarkBackground = () => (
+  <div className="bg-gray-900 p-8 rounded-xl flex items-center gap-6">
+    <Spinner color="white" size="sm" />
+    <Spinner color="white" size="md" />
+    <Spinner color="white" size="lg" />
+  </div>
+);
+
+export const InlineWithText = () => (
+  <div className="flex items-center gap-3">
+    <Spinner size="sm" />
+    <span className="text-gray-600">Loading artworks...</span>
+  </div>
+);

--- a/src/lib/__tests__/Badge.test.jsx
+++ b/src/lib/__tests__/Badge.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Badge from '../Badge';
+
+describe('Badge Component', () => {
+  test('renders children', () => {
+    render(<Badge>Status</Badge>);
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  test('renders primary variant by default', () => {
+    render(<Badge>Primary</Badge>);
+    expect(screen.getByText('Primary')).toHaveClass('bg-purple-100');
+  });
+
+  test('renders success variant', () => {
+    render(<Badge variant="success">Active</Badge>);
+    expect(screen.getByText('Active')).toHaveClass('bg-green-100');
+  });
+
+  test('renders warning variant', () => {
+    render(<Badge variant="warning">Pending</Badge>);
+    expect(screen.getByText('Pending')).toHaveClass('bg-yellow-100');
+  });
+
+  test('renders danger variant', () => {
+    render(<Badge variant="danger">Error</Badge>);
+    expect(screen.getByText('Error')).toHaveClass('bg-red-100');
+  });
+
+  test('renders info variant', () => {
+    render(<Badge variant="info">Info</Badge>);
+    expect(screen.getByText('Info')).toHaveClass('bg-blue-100');
+  });
+
+  test('renders outline variant', () => {
+    render(<Badge variant="outline">Outline</Badge>);
+    expect(screen.getByText('Outline')).toHaveClass('bg-transparent');
+  });
+
+  test('renders with different sizes', () => {
+    const { rerender } = render(<Badge size="sm">Small</Badge>);
+    expect(screen.getByText('Small')).toHaveClass('text-xs');
+
+    rerender(<Badge size="lg">Large</Badge>);
+    expect(screen.getByText('Large')).toHaveClass('text-base');
+  });
+
+  test('renders with icon', () => {
+    const MockIcon = () => <svg data-testid="badge-icon" />;
+    render(<Badge icon={MockIcon}>With Icon</Badge>);
+    expect(screen.getByTestId('badge-icon')).toBeInTheDocument();
+  });
+
+  test('accepts custom className', () => {
+    render(<Badge className="custom-badge">Custom</Badge>);
+    expect(screen.getByText('Custom')).toHaveClass('custom-badge');
+  });
+});

--- a/src/lib/__tests__/Button.test.jsx
+++ b/src/lib/__tests__/Button.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { Button } from '../index';
+
+describe('Button Component', () => {
+  test('renders with default props', () => {
+    render(<Button>Click me</Button>);
+    const button = screen.getByRole('button', { name: 'Click me' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass('bg-gradient-to-r');
+  });
+
+  test('renders primary variant by default', () => {
+    render(<Button>Primary</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('from-purple-600');
+  });
+
+  test('renders secondary variant', () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('bg-white');
+  });
+
+  test('renders ghost variant', () => {
+    render(<Button variant="ghost">Ghost</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('hover:bg-gray-100');
+  });
+
+  test('renders with different sizes', () => {
+    const { rerender } = render(<Button size="sm">Small</Button>);
+    expect(screen.getByRole('button')).toHaveClass('px-3');
+
+    rerender(<Button size="lg">Large</Button>);
+    expect(screen.getByRole('button')).toHaveClass('px-6');
+  });
+
+  test('handles click events', () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Click me</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows loading state', () => {
+    render(<Button loading>Loading</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(screen.getByTestId('button-loading-spinner')).toBeInTheDocument();
+  });
+
+  test('does not fire click when loading', () => {
+    const handleClick = jest.fn();
+    render(
+      <Button loading onClick={handleClick}>
+        Loading
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    render(<Button disabled>Disabled</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  test('renders with icon', () => {
+    const MockIcon = () => <svg data-testid="mock-icon" />;
+    render(<Button icon={MockIcon}>With Icon</Button>);
+    expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
+  });
+
+  test('accepts custom className', () => {
+    render(<Button className="custom-class">Custom</Button>);
+    expect(screen.getByRole('button')).toHaveClass('custom-class');
+  });
+});

--- a/src/lib/__tests__/Card.test.jsx
+++ b/src/lib/__tests__/Card.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Card, { CardHeader, CardTitle, CardContent, CardFooter } from '../Card';
+
+describe('Card Component', () => {
+  test('renders children', () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  test('applies glass variant classes', () => {
+    const { container } = render(<Card glass>Glass card</Card>);
+    expect(container.firstChild).toHaveClass('backdrop-blur-xl');
+  });
+
+  test('applies padding sizes', () => {
+    const { container } = render(<Card padding="lg">Padded</Card>);
+    expect(container.firstChild).toHaveClass('p-8');
+  });
+
+  test('applies shadow sizes', () => {
+    const { container } = render(<Card shadow="lg">Shadow</Card>);
+    expect(container.firstChild).toHaveClass('shadow-xl');
+  });
+
+  test('disables hover when hover=false', () => {
+    const { container } = render(<Card hover={false}>No hover</Card>);
+    expect(container.firstChild).not.toHaveClass('hover:shadow-xl');
+  });
+
+  test('accepts custom className', () => {
+    const { container } = render(<Card className="custom-class">Custom</Card>);
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});
+
+describe('Card Sub-Components', () => {
+  test('CardHeader renders children', () => {
+    render(<CardHeader>Header</CardHeader>);
+    expect(screen.getByText('Header')).toBeInTheDocument();
+  });
+
+  test('CardTitle renders as h3', () => {
+    render(<CardTitle>Title</CardTitle>);
+    const title = screen.getByText('Title');
+    expect(title.tagName).toBe('H3');
+    expect(title).toHaveClass('font-bold');
+  });
+
+  test('CardContent renders children', () => {
+    render(<CardContent>Content</CardContent>);
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  test('CardFooter renders with border', () => {
+    render(<CardFooter>Footer</CardFooter>);
+    const footer = screen.getByText('Footer');
+    expect(footer).toHaveClass('border-t');
+  });
+});

--- a/src/lib/__tests__/Modal.test.jsx
+++ b/src/lib/__tests__/Modal.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import Modal from '../Modal';
+
+describe('Modal Component', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    title: 'Test Modal',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders when isOpen is true', () => {
+    render(<Modal {...defaultProps}>Modal content</Modal>);
+    expect(screen.getByText('Modal content')).toBeInTheDocument();
+    expect(screen.getByText('Test Modal')).toBeInTheDocument();
+  });
+
+  test('does not render when isOpen is false', () => {
+    render(
+      <Modal {...defaultProps} isOpen={false}>
+        Modal content
+      </Modal>,
+    );
+    expect(screen.queryByText('Modal content')).not.toBeInTheDocument();
+  });
+
+  test('renders close button by default', () => {
+    render(<Modal {...defaultProps}>Content</Modal>);
+    expect(screen.getByTestId('modal-close-button')).toBeInTheDocument();
+  });
+
+  test('calls onClose when close button is clicked', () => {
+    render(<Modal {...defaultProps}>Content</Modal>);
+    fireEvent.click(screen.getByTestId('modal-close-button'));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClose on Escape key', () => {
+    render(<Modal {...defaultProps}>Content</Modal>);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('hides close button when showCloseButton is false', () => {
+    render(
+      <Modal {...defaultProps} showCloseButton={false}>
+        Content
+      </Modal>,
+    );
+    expect(screen.queryByTestId('modal-close-button')).not.toBeInTheDocument();
+  });
+
+  test('accepts custom className', () => {
+    render(
+      <Modal {...defaultProps} className="custom-modal">
+        Content
+      </Modal>,
+    );
+    expect(screen.getByRole('dialog')).toHaveClass('custom-modal');
+  });
+
+  test('renders without title', () => {
+    render(
+      <Modal isOpen={true} onClose={jest.fn()}>
+        Content only
+      </Modal>,
+    );
+    expect(screen.getByText('Content only')).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/Spinner.test.jsx
+++ b/src/lib/__tests__/Spinner.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Spinner from '../Spinner';
+
+describe('Spinner Component', () => {
+  test('renders with default props', () => {
+    render(<Spinner />);
+    const spinner = screen.getByTestId('spinner');
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass('w-8', 'h-8');
+  });
+
+  test('renders with small size', () => {
+    render(<Spinner size="sm" />);
+    expect(screen.getByTestId('spinner')).toHaveClass('w-5', 'h-5');
+  });
+
+  test('renders with large size', () => {
+    render(<Spinner size="lg" />);
+    expect(screen.getByTestId('spinner')).toHaveClass('w-12', 'h-12');
+  });
+
+  test('renders with different colors', () => {
+    const { rerender } = render(<Spinner color="blue" />);
+    expect(screen.getByTestId('spinner')).toHaveClass('border-blue-600');
+
+    rerender(<Spinner color="green" />);
+    expect(screen.getByTestId('spinner')).toHaveClass('border-green-600');
+  });
+
+  test('has status role for accessibility', () => {
+    render(<Spinner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  test('has aria-label for accessibility', () => {
+    render(<Spinner label="Loading data" />);
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Loading data',
+    );
+  });
+
+  test('accepts custom className', () => {
+    render(<Spinner className="custom-spinner" />);
+    expect(screen.getByTestId('spinner')).toHaveClass('custom-spinner');
+  });
+});

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,5 @@
+export { default as Button } from './Button';
+export { default as Card, CardHeader, CardTitle, CardContent, CardFooter } from './Card';
+export { default as Modal } from './Modal';
+export { default as Badge } from './Badge';
+export { default as Spinner } from './Spinner';


### PR DESCRIPTION
## Summary

### Shared Component Library (#45)
- **Button** — Primary, Secondary, Ghost variants with size options
- **Card** — Base card with CardHeader, CardTitle, CardContent, CardFooter sub-components
- **Modal** — Overlay with close button, Escape key dismiss, animation
- **Badge** — 7 variants (primary, secondary, success, warning, danger, info, outline)
- **Spinner** — Multiple sizes and colors with accessibility (`role="status"`)
- Barrel export from `src/lib/index.js`, all accept `className` for customization
- Comprehensive tests for all 5 components

### Storybook (#48)
- Storybook configured with Webpack5 + addon-essentials
- Global decorator with Tailwind CSS import
- Stories for all shared components showing multiple variants and states
- Scripts: `npm run storybook` (port 6006), `npm run build-storybook`

Closes #45
Closes #48

## Test plan
- [ ] `npm test -- --watchAll=false --passWithNoTests` passes
- [ ] `npm run build` succeeds
- [ ] `npm run storybook` launches on port 6006
- [ ] All component variants render correctly in Storybook