### PR TITLE
feat: implement real-time activity feed for Wuta-Wuta trades and mints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ DATABASE_URL=postgresql://...
 
 # Copy to .env and update values
 
+REACT_APP_LIVE_FEED_URL=ws://localhost:3001/live-feed

--- a/server/activityBroadcaster.js
+++ b/server/activityBroadcaster.js
@@ -1,0 +1,149 @@
+const { WebSocketServer, OPEN } = require('ws');
+
+/**
+ * ActivityBroadcaster
+ *
+ * Attaches a WebSocket server to the existing Express HTTP server so both
+ * REST and WebSocket traffic share a single port. The Stellar listener calls
+ * broadcast() when an on-chain event is parsed; every connected frontend
+ * client receives it immediately.
+ *
+ * Client connection: ws://localhost:3001/live-feed
+ *
+ * Message shape sent to clients:
+ * {
+ *   type: 'activity',
+ *   data: {
+ *     id:        string,   // tx hash
+ *     chain:     'STELLAR' | 'EVM',
+ *     type:      'MINT' | 'TRADE' | 'BID' | 'AUCTION' | 'LIST' | 'OTHER',
+ *     from:      string,
+ *     to?:       string,
+ *     tokenId?:  string,
+ *     price?:    number,
+ *     timestamp: number,
+ *     eventType: string,   // raw Stellar event type e.g. 'ARTWORK_SOLD'
+ *   }
+ * }
+ */
+class ActivityBroadcaster {
+  constructor() {
+    this.wss = null;
+  }
+
+  /**
+   * Attach the WebSocket server to an existing http.Server instance.
+   * Must be called after app.listen() returns the server.
+   *
+   * @param {import('http').Server} httpServer
+   */
+  attach(httpServer) {
+    this.wss = new WebSocketServer({ server: httpServer, path: '/live-feed' });
+
+    this.wss.on('connection', (ws, req) => {
+      const ip = req.socket.remoteAddress;
+      console.log(`🔌 Live feed client connected from ${ip}`);
+
+      // Send a welcome ping so the client knows the connection is live
+      this._send(ws, { type: 'connected', message: 'Live feed connected' });
+
+      ws.on('close', () => console.log(`🔌 Live feed client disconnected from ${ip}`));
+      ws.on('error', (err) => console.error(`Live feed WS error from ${ip}:`, err.message));
+    });
+
+    // Heartbeat — ping every 30s, drop dead connections
+    this._startHeartbeat();
+
+    console.log('📡 ActivityBroadcaster attached on path /live-feed');
+  }
+
+  /**
+   * Broadcast a normalised activity event to all connected clients.
+   *
+   * @param {object} rawEvent  Parsed Stellar event from stellarListener
+   * @param {string} txHash    Stellar transaction ID
+   * @param {string} eventType Mapped event type e.g. 'ARTWORK_MINTED'
+   */
+  broadcast(rawEvent, txHash, eventType) {
+    if (!this.wss) return;
+
+    const activity = this._normalise(rawEvent, txHash, eventType);
+    const message  = JSON.stringify({ type: 'activity', data: activity });
+
+    let delivered = 0;
+    this.wss.clients.forEach((ws) => {
+      if (ws.readyState === OPEN) {
+        ws.send(message);
+        delivered++;
+      }
+    });
+
+    if (delivered > 0) {
+      console.log(`📡 Broadcast [${eventType}] → ${delivered} client(s)`);
+    }
+  }
+
+  /** Map a Stellar event to the unified Activity shape the frontend stores. */
+  _normalise(event, txHash, eventType) {
+    const parsed = event.parsedData || {};
+
+    // Map Stellar event types to the frontend's simpler type labels
+    const typeMap = {
+      ARTWORK_MINTED:           'MINT',
+      ARTWORK_SOLD:             'TRADE',
+      AUCTION_ENDED:            'TRADE',
+      BID_MADE:                 'BID',
+      ARTWORK_LISTED:           'LIST',
+      LISTING_CANCELLED:        'LIST',
+      ARTWORK_EVOLVED:          'OTHER',
+      MARKETPLACE_INITIALIZED:  'OTHER',
+    };
+
+    return {
+      id:        txHash,
+      chain:     'STELLAR',
+      type:      typeMap[eventType] || 'OTHER',
+      from:      parsed.seller || parsed.creator || parsed.owner || 'unknown',
+      to:        parsed.buyer  || undefined,
+      tokenId:   parsed.token_id ? String(parsed.token_id) : undefined,
+      price:     parsed.price    || undefined,
+      timestamp: Date.now(),
+      eventType,
+    };
+  }
+
+  /** @private */
+  _send(ws, payload) {
+    if (ws.readyState === OPEN) {
+      ws.send(JSON.stringify(payload));
+    }
+  }
+
+  /** @private Ping/pong heartbeat to detect and clean up dead connections. */
+  _startHeartbeat() {
+    const interval = setInterval(() => {
+      if (!this.wss) return clearInterval(interval);
+      this.wss.clients.forEach((ws) => {
+        if (ws.isAlive === false) return ws.terminate();
+        ws.isAlive = false;
+        ws.ping();
+      });
+    }, 30_000);
+
+    this.wss.on('connection', (ws) => {
+      ws.isAlive = true;
+      ws.on('pong', () => { ws.isAlive = true; });
+    });
+
+    this.wss.on('close', () => clearInterval(interval));
+  }
+
+  async close() {
+    if (!this.wss) return;
+    await new Promise((resolve) => this.wss.close(resolve));
+    console.log('📡 ActivityBroadcaster closed');
+  }
+}
+
+// Export a singleton — both server/index.js and stellarListener share the same instance
+module.exports = new ActivityBroadcaster();

--- a/server/index.js.new
+++ b/server/index.js.new
@@ -3,6 +3,7 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const axios = require('axios');
 const StellarListener = require('./stellarListener.js');
+const broadcaster = require('./activityBroadcaster.js');
 require('dotenv').config();
 
 const app = express();
@@ -12,8 +13,8 @@ let listener;
 
 // Middleware
 app.use(cors({
-  origin: process.env.NODE_ENV === 'production' 
-    ? process.env.FRONTEND_URL 
+  origin: process.env.NODE_ENV === 'production'
+    ? process.env.FRONTEND_URL
     : 'http://localhost:3000',
   credentials: true
 }));
@@ -23,13 +24,13 @@ app.use(bodyParser.urlencoded({ extended: true, limit: '10mb' }));
 // Rate limiting
 const rateLimit = require('express-rate-limit');
 const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
+  windowMs: 15 * 60 * 1000,
   max: 100,
   message: { error: 'Too many requests, please try again later.' }
 });
 app.use('/api/', limiter);
 
-// AI Service (existing)
+// AI Service (unchanged)
 class AIService {
   constructor() {
     this.providers = {
@@ -66,20 +67,23 @@ class AIService {
 
 const aiService = new AIService();
 
-// Existing AI route
+// Existing AI route (unchanged)
 app.post('/api/ai/generate', async (req, res) => {
   // ... (existing code)
 });
 
-// Health check - include listener status
+// Health check — now includes WebSocket client count
 app.get('/api/health', (req, res) => {
-  res.json({ 
-    status: 'healthy', 
+  res.json({
+    status: 'healthy',
     timestamp: new Date().toISOString(),
     services: {
-      openai: !!process.env.OPENAI_API_KEY,
-      huggingface: !!process.env.HUGGINGFACE_API_KEY,
-      stellarListener: listener ? listener.isRunning : false
+      openai:          !!process.env.OPENAI_API_KEY,
+      huggingface:     !!process.env.HUGGINGFACE_API_KEY,
+      stellarListener: listener ? listener.isRunning : false,
+      websocket:       broadcaster.wss
+        ? `${broadcaster.wss.clients.size} client(s) connected`
+        : 'not attached',
     },
     env: {
       hasContractId: !!process.env.STELLAR_CONTRACT_ID
@@ -87,7 +91,7 @@ app.get('/api/health', (req, res) => {
   });
 });
 
-// New Stellar endpoints
+// Stellar endpoints (unchanged)
 app.get('/api/stellar/stats', async (req, res) => {
   const prisma = require('./prisma');
   const stats = await prisma.transaction.groupBy({
@@ -108,27 +112,30 @@ app.get('/api/stellar/recent', async (req, res) => {
 
 // Graceful shutdown
 process.on('SIGINT', async () => {
-  console.log('🛑 Shutting down listener...');
+  console.log('🛑 Shutting down...');
   if (listener) listener.stop();
+  await broadcaster.close();
   process.exit(0);
 });
 
-// Start server + listener
-app.listen(PORT, () => {
+// Start server — capture the http.Server so the WebSocket broadcaster
+// can attach to the same port rather than opening a second one.
+const httpServer = app.listen(PORT, () => {
   console.log(`🚀 Server running on port ${PORT}`);
-  
-  // Start Stellar listener
+
+  // Attach WebSocket broadcaster to the same HTTP server.
+  // Clients connect via ws://localhost:3001/live-feed
+  broadcaster.attach(httpServer);
+
+  // Start Stellar listener — broadcaster is already imported by stellarListener.js
   listener = new StellarListener({
     horizonUrl: process.env.HORIZON_URL,
-    contractId: process.env.STELLAR_CONTRACT_ID
+    contractId: process.env.STELLAR_CONTRACT_ID,
   });
-  
-  listener.start().then(() => {
-    console.log('🌌 Stellar listener started successfully!');
-  }).catch(err => {
-    console.error('❌ Failed to start Stellar listener:', err);
-  });
+
+  listener.start()
+    .then(() => console.log('🌌 Stellar listener started successfully!'))
+    .catch(err => console.error('❌ Failed to start Stellar listener:', err));
 });
 
 module.exports = app;
-

--- a/server/stellarListener.js
+++ b/server/stellarListener.js
@@ -1,5 +1,6 @@
 const { Server } = require('@stellar/stellar-sdk');
 const prisma = require('./prisma.js');
+const broadcaster = require('./activityBroadcaster.js');
 
 class StellarListener {
   constructor(config = {}) {
@@ -38,7 +39,7 @@ class StellarListener {
             this.restart();
           }
         });
-      
+
       this.stream = es;
     } catch (error) {
       console.error('Failed to start listener:', error);
@@ -50,13 +51,11 @@ class StellarListener {
     if (!tx.successful) return;
     if (tx.results?.length === 0) return;
 
-    // Filter for contract invocations
     const contractResults = tx.results.filter(r => r.type === 'invokeContract');
     for (const result of contractResults) {
       const contract = result.contract;
       if (this.contractId && contract !== this.contractId) continue;
 
-      // Parse events
       const events = this.parseEvents(tx, result);
       for (const event of events) {
         await this.handleEvent(tx, event);
@@ -69,10 +68,7 @@ class StellarListener {
     if (result.events) {
       for (const [topic, evs] of Object.entries(result.events)) {
         evs.forEach(ev => {
-          events.push({
-            topic,
-            ...ev
-          });
+          events.push({ topic, ...ev });
         });
       }
     }
@@ -84,27 +80,28 @@ class StellarListener {
     if (!eventType) return;
 
     try {
-      // Store raw event
+      // Persist to DB
       await prisma.transaction.create({
         data: {
           txHash: tx.id,
           contractId: tx.results.find(r => r === event.result)?.contract || '',
           eventType,
-          parsedData: {
-            event,
-            tx,
-          },
+          parsedData: { event, tx },
           blockTimestamp: new Date(tx.created_at),
         }
       });
 
-      console.log(`📝 Recorded event: ${eventType} in tx ${tx.id.slice(0,8)}`);
+      console.log(`📝 Recorded event: ${eventType} in tx ${tx.id.slice(0, 8)}`);
+
+      // Broadcast to all connected WebSocket clients immediately after persisting.
+      // This is the bridge between the server-side Stellar listener and the frontend.
+      broadcaster.broadcast(event, tx.id, eventType);
 
       // Business logic updates
       await this.updateBusinessLogic(eventType, event, tx);
 
     } catch (error) {
-      if (error.code === 'P2002') { // Unique violation
+      if (error.code === 'P2002') {
         console.log(`⚠️ Duplicate tx ${tx.id} skipped`);
       } else {
         console.error('Event processing error:', error);
@@ -114,17 +111,15 @@ class StellarListener {
 
   mapEventType(event) {
     const topic = event.topic || '';
-    const attrs = event.attributes || [];
 
-    // Map contract events to enum
-    if (topic.includes('artwork_minted')) return 'ARTWORK_MINTED';
-    if (topic.includes('artwork_listed')) return 'ARTWORK_LISTED';
-    if (topic.includes('artwork_sold')) return 'ARTWORK_SOLD';
-    if (topic.includes('bid_made')) return 'BID_MADE';
-    if (topic.includes('auction_ended')) return 'AUCTION_ENDED';
-    if (topic.includes('artwork_evolved')) return 'ARTWORK_EVOLVED';
-    if (topic.includes('listing_cancelled')) return 'LISTING_CANCELLED';
-    if (topic.includes('marketplace_initialized')) return 'MARKETPLACE_INITIALIZED';
+    if (topic.includes('artwork_minted'))          return 'ARTWORK_MINTED';
+    if (topic.includes('artwork_listed'))           return 'ARTWORK_LISTED';
+    if (topic.includes('artwork_sold'))             return 'ARTWORK_SOLD';
+    if (topic.includes('bid_made'))                 return 'BID_MADE';
+    if (topic.includes('auction_ended'))            return 'AUCTION_ENDED';
+    if (topic.includes('artwork_evolved'))          return 'ARTWORK_EVOLVED';
+    if (topic.includes('listing_cancelled'))        return 'LISTING_CANCELLED';
+    if (topic.includes('marketplace_initialized'))  return 'MARKETPLACE_INITIALIZED';
 
     return null;
   }
@@ -132,23 +127,21 @@ class StellarListener {
   async updateBusinessLogic(eventType, event, tx) {
     switch (eventType) {
       case 'ARTWORK_SOLD':
-      case 'AUCTION_ENDED':
-        // Create TradeHistory
+      case 'AUCTION_ENDED': {
         const parsed = event.parsedData || {};
         await prisma.tradeHistory.create({
           data: {
             transactionHash: tx.id,
-            price: parsed.price || 0,
+            price:     parsed.price   || 0,
             artAssetId: parsed.token_id ? `asset_${parsed.token_id}` : null,
-            sellerId: parsed.seller || null,
-            buyerId: parsed.buyer || null,
+            sellerId:  parsed.seller  || null,
+            buyerId:   parsed.buyer   || null,
           }
         });
         break;
+      }
       case 'ARTWORK_EVOLVED':
-        // Update Evolution or ArtAsset
         break;
-      // Add more cases
     }
   }
 
@@ -168,4 +161,3 @@ class StellarListener {
 }
 
 module.exports = StellarListener;
-

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -8,7 +8,7 @@ import {
   ArrowDownRight
 } from 'lucide-react';
 import { AreaChart, Area, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip as ChartTooltip, ResponsiveContainer } from 'recharts';
-
+import { LiveActivityFeed } from './LiveActivityFeed';
 import { Card, CardHeader, CardTitle, CardContent } from './ui';
 
 const Dashboard = () => {
@@ -66,6 +66,7 @@ const Dashboard = () => {
 
   return (
     <div className="space-y-6 px-4 sm:px-6 lg:px-8 py-8 max-w-7xl mx-auto">
+      <LiveActivityFeed maxItems={25} />
       {/* Header */}
       <div>
         <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Muse Analytics Dashboard</h1>

--- a/src/components/LiveActivityFeed.tsx
+++ b/src/components/LiveActivityFeed.tsx
@@ -1,0 +1,180 @@
+import { useActivityStore, type Activity } from '../store/useActivityStore';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+function timeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60)  return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  return `${Math.floor(seconds / 3600)}h ago`;
+}
+
+// ── Badge components ──────────────────────────────────────────────────────────
+
+const TYPE_STYLES: Record<Activity['type'], { label: string; className: string }> = {
+  MINT:  { label: 'Mint',    className: 'bg-violet-100 text-violet-700' },
+  TRADE: { label: 'Trade',   className: 'bg-emerald-100 text-emerald-700' },
+  BID:   { label: 'Bid',     className: 'bg-amber-100 text-amber-700' },
+  LIST:  { label: 'Listed',  className: 'bg-sky-100 text-sky-700' },
+  OTHER: { label: 'Event',   className: 'bg-gray-100 text-gray-600' },
+};
+
+const CHAIN_STYLES: Record<Activity['chain'], { label: string; className: string }> = {
+  EVM:     { label: 'EVM',     className: 'bg-indigo-50 text-indigo-600' },
+  STELLAR: { label: 'Stellar', className: 'bg-blue-50 text-blue-600' },
+};
+
+function TypeBadge({ type }: { type: Activity['type'] }) {
+  const { label, className } = TYPE_STYLES[type] ?? TYPE_STYLES.OTHER;
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+function ChainBadge({ chain }: { chain: Activity['chain'] }) {
+  const { label, className } = CHAIN_STYLES[chain];
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Activity row ──────────────────────────────────────────────────────────────
+
+function ActivityRow({ activity }: { activity: Activity }) {
+  return (
+    <li className="flex items-start gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
+      {/* Type + chain badges */}
+      <div className="flex flex-col gap-1 pt-0.5 min-w-[64px]">
+        <TypeBadge type={activity.type} />
+        <ChainBadge chain={activity.chain} />
+      </div>
+
+      {/* Event details */}
+      <div className="flex-1 min-w-0 space-y-0.5">
+        <p className="text-sm text-gray-900 truncate">
+          <span className="font-semibold">{formatAddress(activity.from)}</span>
+          {activity.to && (
+            <>
+              {' → '}
+              <span className="font-semibold">{formatAddress(activity.to)}</span>
+            </>
+          )}
+        </p>
+
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-500">
+          {activity.tokenId && <span>Token #{activity.tokenId}</span>}
+          {activity.price !== undefined && (
+            <span className="font-medium text-gray-700">
+              {activity.price.toLocaleString()} {activity.chain === 'STELLAR' ? 'XLM' : 'ETH'}
+            </span>
+          )}
+          {activity.eventType && (
+            <span className="font-mono text-gray-400">{activity.eventType}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Timestamp */}
+      <time
+        className="text-xs text-gray-400 whitespace-nowrap pt-0.5"
+        dateTime={new Date(activity.timestamp).toISOString()}
+      >
+        {timeAgo(activity.timestamp)}
+      </time>
+    </li>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface LiveActivityFeedProps {
+  /** Maximum rows to display. Defaults to 20. */
+  maxItems?: number;
+  /** Optional CSS class for the outer container. */
+  className?: string;
+}
+
+/**
+ * LiveActivityFeed
+ *
+ * Reads from useActivityStore and renders a scrollable list of real-time
+ * mint and trade events from both EVM and Stellar chains.
+ *
+ * Mount useStellarActivityFeed() and useLiveEngine() at the app root to
+ * populate the store. This component is purely presentational.
+ *
+ * @example
+ *   <LiveActivityFeed maxItems={25} />
+ */
+export function LiveActivityFeed({ maxItems = 20, className = '' }: LiveActivityFeedProps) {
+  const activities = useActivityStore((state) => state.activities);
+  const clear      = useActivityStore((state) => state.clearActivities);
+
+  const visible = activities.slice(0, maxItems);
+
+  return (
+    <div className={`flex flex-col rounded-xl border border-gray-200 bg-white overflow-hidden ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <div className="flex items-center gap-2">
+          {/* Live indicator dot */}
+          <span className="relative flex h-2.5 w-2.5">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500" />
+          </span>
+          <h2 className="text-sm font-semibold text-gray-900">Live Activity Feed</h2>
+          {activities.length > 0 && (
+            <span className="text-xs text-gray-400">({activities.length})</span>
+          )}
+        </div>
+
+        {activities.length > 0 && (
+          <button
+            type="button"
+            onClick={clear}
+            className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Feed */}
+      <div className="overflow-y-auto max-h-[480px]">
+        {visible.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center px-6">
+            <span className="text-3xl mb-3">📡</span>
+            <p className="text-sm font-medium text-gray-700">Waiting for activity</p>
+            <p className="text-xs text-gray-400 mt-1">
+              Mints and trades will appear here in real time.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-100" aria-label="Live activity feed">
+            {visible.map((activity) => (
+              <ActivityRow key={activity.id} activity={activity} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Footer — show count if truncated */}
+      {activities.length > maxItems && (
+        <div className="px-4 py-2 border-t border-gray-100 text-center">
+          <p className="text-xs text-gray-400">
+            Showing {maxItems} of {activities.length} events
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useStellarActivityFeed.ts
+++ b/src/hooks/useStellarActivityFeed.ts
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react';
+import { useActivityStore } from '../store/useActivityStore';
+
+const WS_URL = process.env.REACT_APP_LIVE_FEED_URL || 'ws://localhost:3001/live-feed';
+const RECONNECT_DELAY_MS = 3_000;
+const MAX_RECONNECT_ATTEMPTS = 10;
+
+/**
+ * useStellarActivityFeed
+ *
+ * Opens a WebSocket connection to the server's /live-feed endpoint and
+ * pushes incoming Stellar activity events into useActivityStore.
+ *
+ * Reconnects automatically on disconnect (up to MAX_RECONNECT_ATTEMPTS).
+ * Safe to mount once at the app root — does nothing if the URL is not set.
+ *
+ * @example
+ *   // Mount once in App.tsx or a top-level layout component
+ *   useStellarActivityFeed();
+ */
+export function useStellarActivityFeed() {
+  const addActivity = useActivityStore((state) => state.addActivity);
+  const wsRef       = useRef<WebSocket | null>(null);
+  const attemptsRef = useRef(0);
+  const unmountedRef = useRef(false);
+
+  useEffect(() => {
+    unmountedRef.current = false;
+
+    function connect() {
+      if (unmountedRef.current) return;
+      if (attemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
+        console.warn(`[LiveFeed] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached. Giving up.`);
+        return;
+      }
+
+      const ws = new WebSocket(WS_URL);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        attemptsRef.current = 0;
+        console.log('[LiveFeed] Connected to live feed');
+      };
+
+      ws.onmessage = (event) => {
+        let payload: unknown;
+        try {
+          payload = JSON.parse(event.data);
+        } catch {
+          console.warn('[LiveFeed] Received non-JSON message:', event.data);
+          return;
+        }
+
+        if (!isActivityMessage(payload)) return;
+
+        addActivity({
+          id:        payload.data.id,
+          chain:     'STELLAR',
+          type:      payload.data.type,
+          from:      payload.data.from,
+          to:        payload.data.to,
+          tokenId:   payload.data.tokenId,
+          price:     payload.data.price,
+          timestamp: payload.data.timestamp ?? Date.now(),
+          eventType: payload.data.eventType,
+        });
+      };
+
+      ws.onerror = (err) => {
+        console.error('[LiveFeed] WebSocket error:', err);
+      };
+
+      ws.onclose = () => {
+        if (unmountedRef.current) return;
+        attemptsRef.current += 1;
+        console.log(`[LiveFeed] Disconnected. Reconnecting in ${RECONNECT_DELAY_MS}ms (attempt ${attemptsRef.current})`);
+        setTimeout(connect, RECONNECT_DELAY_MS);
+      };
+    }
+
+    connect();
+
+    return () => {
+      unmountedRef.current = true;
+      wsRef.current?.close();
+    };
+  }, [addActivity]);
+}
+
+// ── Type guard ────────────────────────────────────────────────────────────────
+
+interface ActivityMessage {
+  type: 'activity';
+  data: {
+    id: string;
+    type: 'MINT' | 'TRADE' | 'BID' | 'LIST' | 'OTHER';
+    from: string;
+    to?: string;
+    tokenId?: string;
+    price?: number;
+    timestamp?: number;
+    eventType?: string;
+  };
+}
+
+function isActivityMessage(payload: unknown): payload is ActivityMessage {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as any).type === 'activity' &&
+    typeof (payload as any).data === 'object'
+  );
+}

--- a/src/store/useActivityStore.ts
+++ b/src/store/useActivityStore.ts
@@ -1,24 +1,36 @@
-// src/store/useActivityStore.ts
 import { create } from 'zustand';
 
-interface Activity {
+export interface Activity {
   id: string;
-  type: 'MINT' | 'TRADE';
+  /** Which blockchain this event came from. */
+  chain: 'EVM' | 'STELLAR';
+  type: 'MINT' | 'TRADE' | 'BID' | 'LIST' | 'OTHER';
   from: string;
   to?: string;
-  tokenId: string;
+  tokenId?: string;
+  /** Sale/bid price in the chain's native asset (XLM for Stellar, ETH for EVM). */
+  price?: number;
   timestamp: number;
+  /** Raw event type string from the chain e.g. 'ARTWORK_SOLD', 'Transfer'. */
+  eventType?: string;
 }
 
 interface ActivityState {
   activities: Activity[];
   addActivity: (activity: Activity) => void;
+  clearActivities: () => void;
 }
 
 export const useActivityStore = create<ActivityState>((set) => ({
   activities: [],
-  addActivity: (activity) => 
-    set((state) => ({ 
-      activities: [activity, ...state.activities].slice(0, 50) // Keep last 50
+
+  addActivity: (activity) =>
+    set((state) => ({
+      // Deduplicate by id — EVM and Stellar can both fire for the same tx
+      activities: state.activities.some((a) => a.id === activity.id)
+        ? state.activities
+        : [activity, ...state.activities].slice(0, 50),
     })),
+
+  clearActivities: () => set({ activities: [] }),
 }));


### PR DESCRIPTION
## Summary
Builds the "Live Engine" dashboard feature — a real-time activity feed
that shows every mint and trade happening across EVM and Stellar chains
as they occur on-chain.

## Changes

### New: `server/activityBroadcaster.js`
- WebSocket server attached to the existing Express HTTP server (same port,
  no second server)
- Exported as a singleton so `stellarListener.js` and `index.js` share the
  same instance
- Normalises raw Stellar events into the unified `Activity` shape
- Ping/pong heartbeat to detect and clean up dead connections
- Clients connect via `ws://localhost:3001/live-feed`

### Updated: `server/stellarListener.js`
- Calls `broadcaster.broadcast()` inside `handleEvent` after every DB write
- All existing logic unchanged

### Updated: `server/index.js.new`
- Captures the `http.Server` returned by `app.listen()` and passes it to
  `broadcaster.attach(httpServer)` — the key change that lets WebSocket and
  REST share port 3001
- All existing routes and middleware unchanged

### Updated: `src/store/useActivityStore.ts`
- Added `chain: 'EVM' | 'STELLAR'`, `price?: number`, `eventType?: string`
  to the `Activity` interface
- Added deduplication by `id` to prevent duplicate events if both chains
  fire for the same transaction
- Added `clearActivities()` action for the feed's clear button

### New: `src/hooks/useStellarActivityFeed.ts`
- WebSocket client hook that connects to `/live-feed` and pushes Stellar
  events into `useActivityStore`
- Auto-reconnects up to 10 times with a 3s delay on disconnect
- Type-safe message parsing with a runtime type guard

### New: `src/components/LiveActivityFeed.tsx`
- Scrollable feed UI showing type badges (Mint/Trade/Bid/Listed),
  chain badges (EVM/Stellar), truncated addresses, price in the correct
  unit (XLM for Stellar, ETH for EVM), and relative timestamps
- Live pulsing indicator dot in the header
- Clear button to reset the feed
- Empty state when no events have arrived yet
- Purely presentational — reads from `useActivityStore`

## Integration
Mount the hooks once at the app root:
```jsx
useStellarActivityFeed();
useLiveEngine(process.env.REACT_APP_MUSE_NFT_ADDRESS);
```
Drop the feed into any page or layout:
```jsx
<LiveActivityFeed maxItems={25} />
```
Add to `.env`:
```
REACT_APP_LIVE_FEED_URL=ws://localhost:3001/live-feed
```

## Notes
- `useLiveEngine.ts` (EVM hook) is unchanged — it already feeds the store
- The existing `Dashboard.js` is the recommended placement for the feed UI
- No database schema changes required

Closes #46