### PR TITLE
feat: implement artwork favorites system with persistence (#159)

### DIFF
--- a/backend/src/controllers/favorites.controller.ts
+++ b/backend/src/controllers/favorites.controller.ts
@@ -1,0 +1,426 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// ── Schemas ────────────────────────────────────────────────────────────────
+
+export const CreateCollectionSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  coverImage: z.string().url().optional(),
+  isPublic: z.boolean().default(true),
+});
+
+export const UpdateCollectionSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).optional(),
+  coverImage: z.string().url().optional(),
+  isPublic: z.boolean().optional(),
+});
+
+// Helper to get user ID from request (would come from auth middleware)
+const getUserId = (req: Request): string | null => {
+  // TODO: Extract from auth middleware (e.g., req.user.id)
+  return req.headers['x-user-id'] as string || null;
+};
+
+// ============ FAVORITES CONTROLLERS ============
+
+/**
+ * GET /api/favorites
+ * Get all favorites for the authenticated user
+ */
+export const getFavorites = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const favorites = await prisma.favorite.findMany({
+      where: { userId },
+      include: {
+        artAsset: {
+          select: {
+            id: true,
+            title: true,
+            imageUrl: true,
+            price: true,
+            creator: { select: { username: true, walletAddress: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.status(200).json({
+      success: true,
+      data: favorites.map(f => ({
+        id: f.id,
+        artwork: f.artAsset,
+        favoritedAt: f.createdAt,
+      })),
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * POST /api/favorites/:artworkId
+ * Add artwork to favorites
+ */
+export const addFavorite = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { artworkId } = req.params;
+
+    // Check if artwork exists
+    const artwork = await prisma.artAsset.findUnique({ where: { id: artworkId } });
+    if (!artwork) {
+      res.status(404).json({ success: false, error: 'Artwork not found' });
+      return;
+    }
+
+    // Check if already favorited
+    const existing = await prisma.favorite.findUnique({
+      where: { userId_artAssetId: { userId, artAssetId: artworkId } },
+    });
+
+    if (existing) {
+      res.status(200).json({ success: true, data: existing, message: 'Already favorited' });
+      return;
+    }
+
+    const favorite = await prisma.favorite.create({
+      data: { userId, artAssetId: artworkId },
+      include: { artAsset: true },
+    });
+
+    res.status(201).json({ success: true, data: favorite });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * DELETE /api/favorites/:artworkId
+ * Remove artwork from favorites
+ */
+export const removeFavorite = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { artworkId } = req.params;
+
+    await prisma.favorite.delete({
+      where: { userId_artAssetId: { userId, artAssetId: artworkId } },
+    });
+
+    res.status(200).json({ success: true, message: 'Removed from favorites' });
+  } catch (err) {
+    // If not found, just return success
+    if ((err as any).code === 'P2025') {
+      res.status(200).json({ success: true, message: 'Not in favorites' });
+      return;
+    }
+    next(err);
+  }
+};
+
+// ============ COLLECTIONS CONTROLLERS ============
+
+/**
+ * GET /api/favorites/collections
+ * Get all collections for the authenticated user
+ */
+export const getCollections = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const collections = await prisma.collection.findMany({
+      where: { userId },
+      include: {
+        _count: { select: { artworks: true } },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    res.status(200).json({
+      success: true,
+      data: collections.map(c => ({
+        id: c.id,
+        name: c.name,
+        description: c.description,
+        coverImage: c.coverImage,
+        isPublic: c.isPublic,
+        artworkCount: c._count.artworks,
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+      })),
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * GET /api/favorites/collections/:id
+ * Get single collection with artworks
+ */
+export const getCollection = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { id } = req.params;
+
+    const collection = await prisma.collection.findFirst({
+      where: { id, userId },
+      include: {
+        artworks: {
+          include: {
+            artAsset: {
+              select: {
+                id: true,
+                title: true,
+                imageUrl: true,
+                price: true,
+                creator: { select: { username: true, walletAddress: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!collection) {
+      res.status(404).json({ success: false, error: 'Collection not found' });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      data: {
+        id: collection.id,
+        name: collection.name,
+        description: collection.description,
+        coverImage: collection.coverImage,
+        isPublic: collection.isPublic,
+        artworks: collection.artworks.map(a => ({
+          id: a.artAsset.id,
+          title: a.artAsset.title,
+          imageUrl: a.artAsset.imageUrl,
+          price: a.artAsset.price,
+          creator: a.artAsset.creator,
+          addedAt: a.addedAt,
+        })),
+        createdAt: collection.createdAt,
+        updatedAt: collection.updatedAt,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * POST /api/favorites/collections
+ * Create a new collection
+ */
+export const createCollection = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const validation = CreateCollectionSchema.safeParse(req.body);
+    if (!validation.success) {
+      res.status(400).json({ success: false, error: 'Invalid input', details: validation.error });
+      return;
+    }
+
+    const { name, description, coverImage, isPublic } = validation.data;
+
+    const collection = await prisma.collection.create({
+      data: { name, description, coverImage, isPublic, userId },
+    });
+
+    res.status(201).json({ success: true, data: collection });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * PUT /api/favorites/collections/:id
+ * Update collection details
+ */
+export const updateCollection = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { id } = req.params;
+
+    const validation = UpdateCollectionSchema.safeParse(req.body);
+    if (!validation.success) {
+      res.status(400).json({ success: false, error: 'Invalid input', details: validation.error });
+      return;
+    }
+
+    const collection = await prisma.collection.update({
+      where: { id, userId },
+      data: validation.data,
+    });
+
+    res.status(200).json({ success: true, data: collection });
+  } catch (err) {
+    if ((err as any).code === 'P2025') {
+      res.status(404).json({ success: false, error: 'Collection not found' });
+      return;
+    }
+    next(err);
+  }
+};
+
+/**
+ * DELETE /api/favorites/collections/:id
+ * Delete a collection
+ */
+export const deleteCollection = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { id } = req.params;
+
+    await prisma.collection.delete({
+      where: { id, userId },
+    });
+
+    res.status(200).json({ success: true, message: 'Collection deleted' });
+  } catch (err) {
+    if ((err as any).code === 'P2025') {
+      res.status(404).json({ success: false, error: 'Collection not found' });
+      return;
+    }
+    next(err);
+  }
+};
+
+/**
+ * POST /api/favorites/collections/:id/artworks/:artworkId
+ * Add artwork to collection
+ */
+export const addArtworkToCollection = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { id: collectionId, artworkId } = req.params;
+
+    // Verify collection belongs to user
+    const collection = await prisma.collection.findFirst({
+      where: { id: collectionId, userId },
+    });
+
+    if (!collection) {
+      res.status(404).json({ success: false, error: 'Collection not found' });
+      return;
+    }
+
+    // Check if artwork exists
+    const artwork = await prisma.artAsset.findUnique({ where: { id: artworkId } });
+    if (!artwork) {
+      res.status(404).json({ success: false, error: 'Artwork not found' });
+      return;
+    }
+
+    // Check if already in collection
+    const existing = await prisma.collectionArtwork.findUnique({
+      where: { collectionId_artAssetId: { collectionId, artAssetId: artworkId } },
+    });
+
+    if (existing) {
+      res.status(200).json({ success: true, message: 'Artwork already in collection' });
+      return;
+    }
+
+    await prisma.collectionArtwork.create({
+      data: { collectionId, artAssetId: artworkId },
+    });
+
+    res.status(201).json({ success: true, message: 'Artwork added to collection' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * DELETE /api/favorites/collections/:id/artworks/:artworkId
+ * Remove artwork from collection
+ */
+export const removeArtworkFromCollection = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    const { id: collectionId, artworkId } = req.params;
+
+    // Verify collection belongs to user
+    const collection = await prisma.collection.findFirst({
+      where: { id: collectionId, userId },
+    });
+
+    if (!collection) {
+      res.status(404).json({ success: false, error: 'Collection not found' });
+      return;
+    }
+
+    await prisma.collectionArtwork.delete({
+      where: { collectionId_artAssetId: { collectionId, artAssetId: artworkId } },
+    });
+
+    res.status(200).json({ success: true, message: 'Artwork removed from collection' });
+  } catch (err) {
+    if ((err as any).code === 'P2025') {
+      res.status(200).json({ success: true, message: 'Artwork not in collection' });
+      return;
+    }
+    next(err);
+  }
+};

--- a/backend/src/routes/favorites.routes.ts
+++ b/backend/src/routes/favorites.routes.ts
@@ -1,0 +1,93 @@
+import { Router } from 'express';
+import {
+  // Favorites
+  getFavorites,
+  addFavorite,
+  removeFavorite,
+  // Collections
+  getCollections,
+  getCollection,
+  createCollection,
+  updateCollection,
+  deleteCollection,
+  addArtworkToCollection,
+  removeArtworkFromCollection,
+} from '../controllers/favorites.controller';
+
+const router = Router();
+
+// ============ FAVORITES ============
+
+/**
+ * @route  GET /api/favorites
+ * @desc   Get user's favorites
+ * @access Protected
+ */
+router.get('/', getFavorites);
+
+/**
+ * @route  POST /api/favorites/:artworkId
+ * @desc   Add artwork to favorites
+ * @access Protected
+ */
+router.post('/:artworkId', addFavorite);
+
+/**
+ * @route  DELETE /api/favorites/:artworkId
+ * @desc   Remove artwork from favorites
+ * @access Protected
+ */
+router.delete('/:artworkId', removeFavorite);
+
+// ============ COLLECTIONS ============
+
+/**
+ * @route  GET /api/collections
+ * @desc   Get user's collections
+ * @access Protected
+ */
+router.get('/collections', getCollections);
+
+/**
+ * @route  GET /api/collections/:id
+ * @desc   Get single collection with artworks
+ * @access Protected
+ */
+router.get('/collections/:id', getCollection);
+
+/**
+ * @route  POST /api/collections
+ * @desc   Create a new collection
+ * @access Protected
+ */
+router.post('/collections', createCollection);
+
+/**
+ * @route  PUT /api/collections/:id
+ * @desc   Update collection details
+ * @access Protected
+ */
+router.put('/collections/:id', updateCollection);
+
+/**
+ * @route  DELETE /api/collections/:id
+ * @desc   Delete a collection
+ * @access Protected
+ */
+router.delete('/collections/:id', deleteCollection);
+
+/**
+ * @route  POST /api/collections/:id/artworks/:artworkId
+ * @desc   Add artwork to collection
+ * @access Protected
+ */
+router.post('/collections/:id/artworks/:artworkId', addArtworkToCollection);
+
+/**
+ * @route  DELETE /api/collections/:id/artworks/:artworkId
+ * @desc   Remove artwork from collection
+ * @access Protected
+ */
+router.delete('/collections/:id/artworks/:artworkId', removeArtworkFromCollection);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import authRoutes from './auth.routes';
 import artRoutes from './art.routes';
 import blockchainRoutes from './blockchain.routes';
+import favoritesRoutes from './favorites.routes';
 
 const router = Router();
 
@@ -21,5 +22,6 @@ router.get('/health', (_req, res) => {
 router.use('/auth', authRoutes);
 router.use('/art', artRoutes);
 router.use('/blockchain', blockchainRoutes);
+router.use('/favorites', favoritesRoutes);
 
 export default router;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,54 @@ model User {
   bids            Bid[]
   tradesAsSeller  TradeHistory[] @relation("Seller")
   tradesAsBuyer   TradeHistory[] @relation("Buyer")
+  
+  // Favorites & Collections
+  favorites       Favorite[]
+  collections     Collection[]
+}
+
+// Favorites - users can favorite any artwork
+model Favorite {
+  id          String   @id @default(uuid())
+  user        User     @relation(fields: [userId], references: [id])
+  userId      String
+  artAsset    ArtAsset @relation(fields: [artAssetId], references: [id])
+  artAssetId  String
+  createdAt   DateTime @default(now())
+
+  @@unique([userId, artAssetId]) // One favorite per artwork per user
+  @@index([userId])
+  @@index([artAssetId])
+}
+
+// Collections - users can organize artworks into custom collections
+model Collection {
+  id          String        @id @default(uuid())
+  name        String
+  description String?
+  coverImage  String?
+  isPublic    Boolean       @default(true)
+  user        User          @relation(fields: [userId], references: [id])
+  userId      String
+  artworks    CollectionArtwork[]
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  @@index([userId])
+}
+
+// Junction table for Collection <-> ArtAsset many-to-many
+model CollectionArtwork {
+  id           String     @id @default(uuid())
+  collection   Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  collectionId String
+  artAsset     ArtAsset   @relation(fields: [artAssetId], references: [id])
+  artAssetId   String
+  addedAt      DateTime   @default(now())
+
+  @@unique([collectionId, artAssetId])
+  @@index([collectionId])
+  @@index([artAssetId])
 }
 
 model ArtAsset {
@@ -58,6 +106,10 @@ model ArtAsset {
   evolutions        Evolution[]
   bids              Bid[]
   tradeHistory      TradeHistory[]
+  
+  // Favorites & Collections relations
+  favorites         Favorite[]
+  collectionItems    CollectionArtwork[]
   
   createdAt         DateTime       @default(now())
   updatedAt         DateTime       @updatedAt

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { LayoutDashboard, Image, PlusCircle, History, Sparkles, Settings as SettingsIcon, Send } from 'lucide-react';
+import { LayoutDashboard, Image, PlusCircle, History, Sparkles, Settings as SettingsIcon, Send, Heart } from 'lucide-react';
 
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
@@ -10,6 +10,7 @@ import Gallery from './components/Gallery';
 import CreateArt from './components/CreateArt';
 import Settings from './components/Settings';
 import TransactionHistory from './components/TransactionHistory';
+import FavoritesPage from './pages/FavoritesPage';
 import ThemeProvider from './contexts/ThemeContext';
 import { useWalletStore } from './store/walletStore';
 import { useMuseStore } from './store/museStore';
@@ -51,6 +52,7 @@ const App = () => {
   const navigation = useMemo(
     () => [
       { id: 'dashboard', name: 'Dashboard', icon: LayoutDashboard },
+      { id: 'favorites', name: 'Favorites', icon: Heart },
       { id: 'gallery', name: 'Gallery', icon: Image },
       { id: 'create', name: 'Create', icon: PlusCircle },
       { id: 'minting', name: 'Minting', icon: Send },
@@ -78,6 +80,8 @@ const App = () => {
     switch (activeTab) {
       case 'dashboard':
         return <Dashboard />;
+      case 'favorites':
+        return <FavoritesPage />;
       case 'minting':
         return <MintingDashboard />;
       case 'create':

--- a/src/components/ArtworkGrid.js
+++ b/src/components/ArtworkGrid.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { ShoppingCart, Eye, Sparkles, TrendingUp } from 'lucide-react';
+import FavoriteButton from './FavoriteButton';
 
 // ---------------------------------------------------------------------------
 // ArtCardSkeleton — shimmering placeholder while Stellar data loads
@@ -81,6 +82,15 @@ const ArtCard = ({ artwork, listing, onBuyArtwork, onAnalyzeArtwork, address }) 
               <TrendingUp className="w-3 h-3" /> Evolvable
             </span>
           )}
+        </div>
+
+        {/* Favorite button */}
+        <div className="absolute top-3 right-3">
+          <FavoriteButton 
+            artworkId={artwork.id} 
+            artworkTitle={artwork.title}
+            size="sm"
+          />
         </div>
 
         {/* Analyse button (owner only, unanalysed) */}

--- a/src/components/CollectionsManager.js
+++ b/src/components/CollectionsManager.js
@@ -1,0 +1,404 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  FolderPlus, 
+  MoreVertical, 
+  Trash2, 
+  Edit2, 
+  Lock, 
+  Globe, 
+  Plus,
+  X,
+  Check,
+  Image
+} from 'lucide-react';
+import useFavoritesStore from '../store/favoritesStore';
+
+/**
+ * CollectionsManager - UI for managing user collections
+ * 
+ * Features:
+ * - View all collections
+ * - Create new collections
+ * - Edit collection details
+ * - Delete collections
+ * - Toggle public/private visibility
+ * - Add artworks to collections
+ */
+const CollectionsManager = ({ 
+  onClose, 
+  onSelectCollection,
+  mode = 'manage' // 'manage' | 'select'
+}) => {
+  const { 
+    collections, 
+    collectionsLoading,
+    fetchCollections,
+    createCollection,
+    updateCollection,
+    deleteCollection,
+    addToCollection,
+    removeFromCollection
+  } = useFavoritesStore();
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingCollection, setEditingCollection] = useState(null);
+  const [newCollection, setNewCollection] = useState({ name: '', description: '', isPublic: true });
+  const [actionLoading, setActionLoading] = useState(null);
+
+  useEffect(() => {
+    fetchCollections();
+  }, []);
+
+  const handleCreateCollection = async (e) => {
+    e.preventDefault();
+    if (!newCollection.name.trim()) return;
+
+    setActionLoading('creating');
+    await createCollection(newCollection);
+    setNewCollection({ name: '', description: '', isPublic: true });
+    setShowCreateForm(false);
+    setActionLoading(null);
+  };
+
+  const handleUpdateCollection = async (collectionId, data) => {
+    setActionLoading(`updating-${collectionId}`);
+    await updateCollection(collectionId, data);
+    setEditingCollection(null);
+    setActionLoading(null);
+  };
+
+  const handleDeleteCollection = async (collectionId) => {
+    if (!window.confirm('Are you sure you want to delete this collection?')) return;
+    
+    setActionLoading(`deleting-${collectionId}`);
+    await deleteCollection(collectionId);
+    setActionLoading(null);
+  };
+
+  const handleToggleVisibility = async (collection) => {
+    await updateCollection(collection.id, { isPublic: !collection.isPublic });
+  };
+
+  if (collectionsLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-xl max-w-md w-full max-h-[80vh] overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="p-4 border-b border-gray-100 flex items-center justify-between">
+        <h2 className="text-lg font-bold text-gray-900">My Collections</h2>
+        <button onClick={onClose} className="p-1 hover:bg-gray-100 rounded-lg transition-colors">
+          <X className="w-5 h-5 text-gray-500" />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {/* Create new collection button/form */}
+        {showCreateForm ? (
+          <form onSubmit={handleCreateCollection} className="bg-gray-50 rounded-xl p-4 space-y-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Collection Name</label>
+              <input
+                type="text"
+                value={newCollection.name}
+                onChange={(e) => setNewCollection({ ...newCollection, name: e.target.value })}
+                placeholder="My Favorite Artworks"
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+                maxLength={100}
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Description (optional)</label>
+              <textarea
+                value={newCollection.description}
+                onChange={(e) => setNewCollection({ ...newCollection, description: e.target.value })}
+                placeholder="A collection description..."
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none"
+                rows={2}
+                maxLength={500}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="isPublic"
+                checked={newCollection.isPublic}
+                onChange={(e) => setNewCollection({ ...newCollection, isPublic: e.target.checked })}
+                className="w-4 h-4 text-purple-600 rounded focus:ring-purple-500"
+              />
+              <label htmlFor="isPublic" className="text-sm text-gray-600">Make this collection public</label>
+            </div>
+            <div className="flex gap-2 pt-2">
+              <button
+                type="submit"
+                disabled={actionLoading === 'creating' || !newCollection.name.trim()}
+                className="flex-1 flex items-center justify-center gap-1 px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 disabled:opacity-50 transition-colors"
+              >
+                <Check className="w-4 h-4" />
+                Create
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowCreateForm(false); setNewCollection({ name: '', description: '', isPublic: true }); }}
+                className="px-4 py-2 bg-gray-100 text-gray-600 rounded-lg text-sm font-medium hover:bg-gray-200 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        ) : (
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="w-full flex items-center gap-2 px-4 py-3 border-2 border-dashed border-gray-200 rounded-xl text-gray-500 hover:border-purple-300 hover:text-purple-600 hover:bg-purple-50 transition-colors"
+          >
+            <FolderPlus className="w-5 h-5" />
+            <span className="text-sm font-medium">Create New Collection</span>
+          </button>
+        )}
+
+        {/* Collections list */}
+        {collections.length === 0 && !showCreateForm ? (
+          <div className="text-center py-8 text-gray-400">
+            <FolderPlus className="w-12 h-12 mx-auto mb-2 opacity-30" />
+            <p className="text-sm">No collections yet</p>
+            <p className="text-xs mt-1">Create a collection to organize your favorite artworks</p>
+          </div>
+        ) : (
+          collections.map((collection) => (
+            <div 
+              key={collection.id}
+              className="bg-gray-50 rounded-xl p-4 hover:bg-gray-100 transition-colors"
+            >
+              {editingCollection === collection.id ? (
+                // Edit mode
+                <EditCollectionForm 
+                  collection={collection}
+                  onSave={(data) => handleUpdateCollection(collection.id, data)}
+                  onCancel={() => setEditingCollection(null)}
+                  isLoading={actionLoading === `updating-${collection.id}`}
+                />
+              ) : (
+                // Display mode
+                <div className="flex items-start justify-between">
+                  <div 
+                    className="flex-1 cursor-pointer"
+                    onClick={() => mode === 'select' && onSelectCollection(collection)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-semibold text-gray-900 text-sm">{collection.name}</h3>
+                      {collection.isPublic ? (
+                        <Globe className="w-3.5 h-3.5 text-gray-400" />
+                      ) : (
+                        <Lock className="w-3.5 h-3.5 text-gray-400" />
+                      )}
+                    </div>
+                    {collection.description && (
+                      <p className="text-xs text-gray-500 mt-1 line-clamp-2">{collection.description}</p>
+                    )}
+                    <p className="text-xs text-gray-400 mt-2">
+                      {collection.artworkCount || 0} artwork{collection.artworkCount !== 1 ? 's' : ''}
+                    </p>
+                  </div>
+
+                  {/* Actions */}
+                  {mode === 'manage' && (
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => setEditingCollection(collection.id)}
+                        className="p-1.5 text-gray-400 hover:text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+                        title="Edit collection"
+                      >
+                        <Edit2 className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => handleToggleVisibility(collection)}
+                        className="p-1.5 text-gray-400 hover:text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+                        title={collection.isPublic ? 'Make private' : 'Make public'}
+                      >
+                        {collection.isPublic ? <Lock className="w-4 h-4" /> : <Globe className="w-4 h-4" />}
+                      </button>
+                      <button
+                        onClick={() => handleDeleteCollection(collection.id)}
+                        disabled={actionLoading === `deleting-${collection.id}`}
+                        className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                        title="Delete collection"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * EditCollectionForm - Inline form for editing collection details
+ */
+const EditCollectionForm = ({ collection, onSave, onCancel, isLoading }) => {
+  const [name, setName] = useState(collection.name);
+  const [description, setDescription] = useState(collection.description || '');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSave({ name, description });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full px-2 py-1 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        autoFocus
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Description (optional)"
+        className="w-full px-2 py-1 border border-gray-200 rounded text-xs resize-none focus:outline-none focus:ring-2 focus:ring-purple-500"
+        rows={2}
+      />
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isLoading || !name.trim()}
+          className="flex-1 flex items-center justify-center gap-1 px-3 py-1.5 bg-purple-600 text-white rounded text-xs font-medium hover:bg-purple-700 disabled:opacity-50"
+        >
+          <Check className="w-3 h-3" />
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 bg-gray-100 text-gray-600 rounded text-xs font-medium hover:bg-gray-200"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+/**
+ * AddToCollectionModal - Modal to select which collection to add an artwork to
+ */
+export const AddToCollectionModal = ({ artwork, onClose }) => {
+  const { collections, fetchCollections, addToCollection } = useFavoritesStore();
+  const [selectedCollection, setSelectedCollection] = useState(null);
+  const [isAdding, setIsAdding] = useState(false);
+
+  useEffect(() => {
+    fetchCollections();
+  }, []);
+
+  const handleAdd = async () => {
+    if (!selectedCollection) return;
+    
+    setIsAdding(true);
+    const success = await addToCollection(selectedCollection.id, artwork.id);
+    setIsAdding(false);
+    
+    if (success) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-sm w-full overflow-hidden">
+        <div className="p-4 border-b border-gray-100 flex items-center justify-between">
+          <h3 className="font-bold text-gray-900">Add to Collection</h3>
+          <button onClick={onClose} className="p-1 hover:bg-gray-100 rounded-lg">
+            <X className="w-5 h-5 text-gray-500" />
+          </button>
+        </div>
+
+        {/* Artwork preview */}
+        <div className="p-4 border-b border-gray-100">
+          <div className="flex items-center gap-3">
+            <div className="w-16 h-16 rounded-lg overflow-hidden bg-gray-100">
+              {artwork?.imageUrl && (
+                <img src={artwork.imageUrl} alt={artwork.title} className="w-full h-full object-cover" />
+              )}
+            </div>
+            <div>
+              <p className="font-medium text-gray-900 text-sm">{artwork?.title}</p>
+              <p className="text-xs text-gray-500">Select a collection to add this artwork to</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Collections list */}
+        <div className="p-4 max-h-60 overflow-y-auto space-y-2">
+          {collections.length === 0 ? (
+            <p className="text-center text-gray-400 text-sm py-4">No collections yet. Create one first!</p>
+          ) : (
+            collections.map((collection) => (
+              <button
+                key={collection.id}
+                onClick={() => setSelectedCollection(collection)}
+                className={`w-full flex items-center gap-3 p-3 rounded-lg border-2 transition-colors ${
+                  selectedCollection?.id === collection.id
+                    ? 'border-purple-500 bg-purple-50'
+                    : 'border-gray-100 hover:border-gray-200'
+                }`}
+              >
+                <div className="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center">
+                  <Image className="w-5 h-5 text-gray-400" />
+                </div>
+                <div className="flex-1 text-left">
+                  <p className="font-medium text-gray-900 text-sm">{collection.name}</p>
+                  <p className="text-xs text-gray-500">{collection.artworkCount || 0} artworks</p>
+                </div>
+                {selectedCollection?.id === collection.id && (
+                  <Check className="w-5 h-5 text-purple-600" />
+                )}
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="p-4 border-t border-gray-100 flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 bg-gray-100 text-gray-600 rounded-lg text-sm font-medium hover:bg-gray-200"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleAdd}
+            disabled={!selectedCollection || isAdding}
+            className="flex-1 flex items-center justify-center gap-1 px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 disabled:opacity-50"
+          >
+            {isAdding ? (
+              <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            ) : (
+              <>
+                <Plus className="w-4 h-4" />
+                Add
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollectionsManager;

--- a/src/components/FavoriteButton.js
+++ b/src/components/FavoriteButton.js
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from 'react';
+import { Heart } from 'lucide-react';
+import useFavoritesStore from '../store/favoritesStore';
+
+/**
+ * FavoriteButton - A heart button to favorite/unfavorite artworks
+ * 
+ * @param {string} artworkId - The ID of the artwork
+ * @param {string} artworkTitle - The title of the artwork (for accessibility)
+ * @param {string} size - Size variant: 'sm' | 'md' | 'lg'
+ * @param {boolean} showLabel - Whether to show "Favorite" text label
+ * @param {function} onToggle - Optional callback when favorite status changes
+ */
+const FavoriteButton = ({ 
+  artworkId, 
+  artworkTitle,
+  size = 'md', 
+  showLabel = false,
+  onToggle 
+}) => {
+  const { favoriteIds, toggleFavorite, fetchFavorites } = useFavoritesStore();
+  const [isLoading, setIsLoading] = useState(false);
+  
+  const isFavorited = favoriteIds.has(artworkId);
+  
+  // Fetch favorites on mount
+  useEffect(() => {
+    fetchFavorites();
+  }, []);
+  
+  const handleClick = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    if (isLoading) return;
+    
+    setIsLoading(true);
+    await toggleFavorite(artworkId);
+    setIsLoading(false);
+    
+    if (onToggle) {
+      onToggle(!isFavorited);
+    }
+  };
+  
+  // Size classes
+  const sizeClasses = {
+    sm: 'w-5 h-5',
+    md: 'w-6 h-6',
+    lg: 'w-8 h-8',
+  };
+  
+  const buttonSizeClasses = {
+    sm: 'p-1',
+    md: 'p-1.5',
+    lg: 'p-2',
+  };
+  
+  const labelSizeClasses = {
+    sm: 'text-xs',
+    md: 'text-sm',
+    lg: 'text-base',
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isLoading}
+      className={`
+        inline-flex items-center gap-1.5
+        ${buttonSizeClasses[size]}
+        rounded-full
+        transition-all duration-200
+        ${isFavorited 
+          ? 'bg-red-50 text-red-500 hover:bg-red-100' 
+          : 'bg-white/80 text-gray-400 hover:text-red-500 hover:bg-red-50'
+        }
+        ${isLoading ? 'opacity-50 cursor-wait' : 'cursor-pointer'}
+      `}
+      aria-label={isFavorited ? `Remove ${artworkTitle} from favorites` : `Add ${artworkTitle} to favorites`}
+      title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+    >
+      <Heart 
+        className={`${sizeClasses[size]} transition-all duration-200 ${isFavorited ? 'fill-current' : ''}`}
+        strokeWidth={isFavorited ? 2.5 : 2}
+      />
+      {showLabel && (
+        <span className={`${labelSizeClasses[size]} font-medium`}>
+          {isFavorited ? 'Favorited' : 'Favorite'}
+        </span>
+      )}
+    </button>
+  );
+};
+
+export default FavoriteButton;

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Eye, Filter, Search, ShoppingCart, Sparkles, X } from 'lucide-react';
+import { Eye, Filter, Search, ShoppingCart, Sparkles, X, Heart } from 'lucide-react';
 
 import { useMuseStore } from '../store/museStore';
+import FavoriteButton from './FavoriteButton';
 
 function formatAddress(address = '') {
   if (!address) return 'Unknown creator';
@@ -349,6 +350,15 @@ const Gallery = () => {
                           Evolvable
                         </span>
                       )}
+                    </div>
+
+                    {/* Favorite button */}
+                    <div className="absolute right-4 top-4">
+                      <FavoriteButton 
+                        artworkId={artwork.id} 
+                        artworkTitle={artwork.title}
+                        size="sm"
+                      />
                     </div>
                   </div>
 

--- a/src/pages/FavoritesPage.js
+++ b/src/pages/FavoritesPage.js
@@ -1,0 +1,264 @@
+import React, { useEffect, useState } from 'react';
+import { Heart, Folder, Trash2, Edit2, Globe, Lock, Image, X, ShoppingCart } from 'lucide-react';
+import { useMuseStore } from '../store/museStore';
+import useFavoritesStore from '../store/favoritesStore';
+import FavoriteButton from '../components/FavoriteButton';
+import CollectionsManager from '../components/CollectionsManager';
+
+/**
+ * FavoritesPage - Dedicated page for viewing and managing favorites and collections
+ */
+const FavoritesPage = () => {
+  const { artworks, listings, buyArtwork } = useMuseStore();
+  const { 
+    favorites, 
+    favoritesLoading, 
+    fetchFavorites,
+    collections,
+    fetchCollections,
+    removeFavorite
+  } = useFavoritesStore();
+
+  const [activeTab, setActiveTab] = useState('favorites'); // 'favorites' | 'collections'
+  const [showCollectionsManager, setShowCollectionsManager] = useState(false);
+  const [selectedCollection, setSelectedCollection] = useState(null);
+
+  useEffect(() => {
+    fetchFavorites();
+    fetchCollections();
+  }, []);
+
+  // Get full artwork data for favorites
+  const favoriteArtworks = favorites.map(fav => {
+    const artwork = artworks.find(a => a.id === fav.artwork?.id || a.id === fav.artworkId);
+    const listing = listings.find(l => String(l.tokenId) === String(artwork?.id));
+    return {
+      ...artwork,
+      ...fav.artwork,
+      listing,
+      favoritedAt: fav.favoritedAt
+    };
+  }).filter(Boolean);
+
+  const handleBuyArtwork = async (artworkId, price) => {
+    if (buyArtwork) {
+      await buyArtwork(artworkId, price);
+    }
+  };
+
+  const formatAddress = (address = '') => {
+    if (!address) return 'Unknown';
+    if (address.length <= 10) return address;
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  return (
+    <section className="min-h-[calc(100vh-5rem)] bg-gray-50 dark:bg-gray-950 p-6 md:p-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        {/* Header */}
+        <div className="rounded-3xl bg-gradient-to-br from-red-900 via-pink-900 to-rose-900 p-8 text-white shadow-xl">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-pink-200/80">Your Collection</p>
+              <h1 className="text-3xl font-bold">Favorites & Collections</h1>
+              <p className="mt-3 max-w-2xl text-sm text-pink-100/80">
+                Manage your favorite artworks and organize them into custom collections.
+              </p>
+            </div>
+
+            <div className="grid gap-3 rounded-3xl bg-white/10 p-4 backdrop-blur-sm sm:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-wider text-white/60">Favorites</p>
+                <p className="mt-1 text-2xl font-bold">{favorites.length}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wider text-white/60">Collections</p>
+                <p className="mt-1 text-2xl font-bold">{collections.length}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-1 shadow-sm dark:border-gray-800 dark:bg-gray-900 inline-flex">
+          <button
+            onClick={() => setActiveTab('favorites')}
+            className={`flex items-center gap-2 rounded-xl px-6 py-2.5 text-sm font-medium transition-all ${
+              activeTab === 'favorites'
+                ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+            }`}
+          >
+            <Heart className="w-4 h-4" />
+            Favorites
+          </button>
+          <button
+            onClick={() => setActiveTab('collections')}
+            className={`flex items-center gap-2 rounded-xl px-6 py-2.5 text-sm font-medium transition-all ${
+              activeTab === 'collections'
+                ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+            }`}
+          >
+            <Folder className="w-4 h-4" />
+            Collections
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          {activeTab === 'favorites' ? (
+            favoritesLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-600"></div>
+              </div>
+            ) : favoriteArtworks.length === 0 ? (
+              <div className="text-center py-12">
+                <Heart className="mx-auto mb-4 h-12 w-12 text-gray-300" />
+                <p className="text-lg font-semibold text-gray-900 dark:text-white">No favorites yet</p>
+                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  Browse the gallery and click the heart icon to save your favorite artworks
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {favoriteArtworks.map((artwork) => (
+                  <div
+                    key={artwork.id}
+                    className="group overflow-hidden rounded-2xl border border-gray-100 bg-gray-50 dark:border-gray-800 dark:bg-gray-950"
+                  >
+                    <div className="relative aspect-[4/3] overflow-hidden bg-gray-100">
+                      {artwork.imageUrl ? (
+                        <img
+                          src={artwork.imageUrl}
+                          alt={artwork.title}
+                          className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-gray-400">
+                          <Image className="h-10 w-10" />
+                        </div>
+                      )}
+                      <div className="absolute top-3 right-3">
+                        <FavoriteButton
+                          artworkId={artwork.id}
+                          artworkTitle={artwork.title}
+                          size="sm"
+                        />
+                      </div>
+                    </div>
+                    <div className="p-4 space-y-3">
+                      <div>
+                        <h3 className="font-semibold text-gray-900 dark:text-white">{artwork.title}</h3>
+                        <p className="text-xs text-gray-500">
+                          Favorited {new Date(artwork.favoritedAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm text-gray-600 dark:text-gray-400">
+                          {artwork.listing?.price ? `${artwork.listing.price} XLM` : 'Not listed'}
+                        </span>
+                        {artwork.listing?.price && (
+                          <button
+                            onClick={() => handleBuyArtwork(artwork.id, artwork.listing.price)}
+                            className="flex items-center gap-1 px-3 py-1.5 bg-purple-600 text-white text-xs font-medium rounded-lg hover:bg-purple-700"
+                          >
+                            <ShoppingCart className="w-3 h-3" />
+                            Buy
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between mb-6">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Organize your favorite artworks into collections
+                </p>
+                <button
+                  onClick={() => setShowCollectionsManager(true)}
+                  className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-xl hover:bg-purple-700 transition-colors"
+                >
+                  <Folder className="w-4 h-4" />
+                  Manage Collections
+                </button>
+              </div>
+
+              {collections.length === 0 ? (
+                <div className="text-center py-12">
+                  <Folder className="mx-auto mb-4 h-12 w-12 text-gray-300" />
+                  <p className="text-lg font-semibold text-gray-900 dark:text-white">No collections yet</p>
+                  <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                    Create a collection to organize your favorite artworks
+                  </p>
+                  <button
+                    onClick={() => setShowCollectionsManager(true)}
+                    className="mt-4 flex items-center gap-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-xl hover:bg-purple-700"
+                  >
+                    <Folder className="w-4 h-4" />
+                    Create Collection
+                  </button>
+                </div>
+              ) : (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {collections.map((collection) => (
+                    <button
+                      key={collection.id}
+                      onClick={() => {
+                        setSelectedCollection(collection);
+                        setShowCollectionsManager(true);
+                      }}
+                      className="group relative overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 p-6 text-left hover:border-purple-300 hover:shadow-lg dark:border-gray-800 dark:bg-gray-950 transition-all"
+                    >
+                      <div className="flex items-center gap-3 mb-3">
+                        <div className="w-10 h-10 rounded-xl bg-purple-100 dark:bg-purple-900/30 flex items-center justify-center">
+                          <Folder className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+                        </div>
+                        <div>
+                          <h3 className="font-semibold text-gray-900 dark:text-white">{collection.name}</h3>
+                          <div className="flex items-center gap-1 text-xs text-gray-500">
+                            {collection.isPublic ? (
+                              <Globe className="w-3 h-3" />
+                            ) : (
+                              <Lock className="w-3 h-3" />
+                            )}
+                            <span>{collection.artworkCount || 0} artworks</span>
+                          </div>
+                        </div>
+                      </div>
+                      {collection.description && (
+                        <p className="text-sm text-gray-500 line-clamp-2">{collection.description}</p>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Collections Manager Modal */}
+      {showCollectionsManager && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <CollectionsManager
+            onClose={() => {
+              setShowCollectionsManager(false);
+              setSelectedCollection(null);
+            }}
+            onSelectCollection={(collection) => {
+              setSelectedCollection(collection);
+            }}
+            mode="manage"
+          />
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default FavoritesPage;

--- a/src/store/favoritesStore.js
+++ b/src/store/favoritesStore.js
@@ -1,0 +1,340 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const API_URL = '/api';
+
+const useFavoritesStore = create(
+  persist(
+    (set, get) => ({
+      // Favorites State
+      favorites: [],
+      favoriteIds: new Set(), // For O(1) lookup
+      favoritesLoading: false,
+      favoritesError: null,
+
+      // Collections State
+      collections: [],
+      collectionsLoading: false,
+      collectionsError: null,
+
+      // Current collection being viewed
+      currentCollection: null,
+      currentCollectionLoading: false,
+
+      // ============ FAVORITES ACTIONS ============
+
+      /**
+       * Fetch all favorites from API
+       */
+      fetchFavorites: async () => {
+        set({ favoritesLoading: true, favoritesError: null });
+        try {
+          const response = await fetch(`${API_URL}/favorites`, {
+            headers: {
+              'Content-Type': 'application/json',
+              // TODO: Add auth token from wallet store
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            const favoriteIds = new Set(result.data.map((f: any) => f.artwork.id));
+            set({
+              favorites: result.data,
+              favoriteIds,
+              favoritesLoading: false,
+            });
+          } else {
+            throw new Error(result.error || 'Failed to fetch favorites');
+          }
+        } catch (error: any) {
+          set({
+            favoritesError: error.message,
+            favoritesLoading: false,
+          });
+        }
+      },
+
+      /**
+       * Add artwork to favorites
+       */
+      addFavorite: async (artworkId: string) => {
+        const { favoriteIds, favorites } = get();
+        if (favoriteIds.has(artworkId)) return; // Already favorited
+
+        try {
+          const response = await fetch(`${API_URL}/favorites/${artworkId}`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            // Optimistic update
+            const newFavoriteIds = new Set(favoriteIds);
+            newFavoriteIds.add(artworkId);
+            set({
+              favoriteIds: newFavoriteIds,
+              favorites: [result.data, ...favorites],
+            });
+          }
+        } catch (error) {
+          console.error('Failed to add favorite:', error);
+        }
+      },
+
+      /**
+       * Remove artwork from favorites
+       */
+      removeFavorite: async (artworkId: string) => {
+        const { favoriteIds, favorites } = get();
+        if (!favoriteIds.has(artworkId)) return; // Not favorited
+
+        try {
+          const response = await fetch(`${API_URL}/favorites/${artworkId}`, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            const newFavoriteIds = new Set(favoriteIds);
+            newFavoriteIds.delete(artworkId);
+            set({
+              favoriteIds: newFavoriteIds,
+              favorites: favorites.filter((f: any) => f.artwork.id !== artworkId),
+            });
+          }
+        } catch (error) {
+          console.error('Failed to remove favorite:', error);
+        }
+      },
+
+      /**
+       * Toggle favorite status
+       */
+      toggleFavorite: async (artworkId: string) => {
+        const { favoriteIds, addFavorite, removeFavorite } = get();
+        if (favoriteIds.has(artworkId)) {
+          await removeFavorite(artworkId);
+        } else {
+          await addFavorite(artworkId);
+        }
+      },
+
+      /**
+       * Check if artwork is favorited
+       */
+      isFavorited: (artworkId: string) => {
+        return get().favoriteIds.has(artworkId);
+      },
+
+      // ============ COLLECTIONS ACTIONS ============
+
+      /**
+       * Fetch all collections from API
+       */
+      fetchCollections: async () => {
+        set({ collectionsLoading: true, collectionsError: null });
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections`, {
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            set({
+              collections: result.data,
+              collectionsLoading: false,
+            });
+          } else {
+            throw new Error(result.error || 'Failed to fetch collections');
+          }
+        } catch (error: any) {
+          set({
+            collectionsError: error.message,
+            collectionsLoading: false,
+          });
+        }
+      },
+
+      /**
+       * Fetch single collection with artworks
+       */
+      fetchCollection: async (collectionId: string) => {
+        set({ currentCollectionLoading: true });
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections/${collectionId}`, {
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            set({
+              currentCollection: result.data,
+              currentCollectionLoading: false,
+            });
+          } else {
+            throw new Error(result.error || 'Failed to fetch collection');
+          }
+        } catch (error: any) {
+          set({ currentCollectionLoading: false });
+          console.error('Failed to fetch collection:', error);
+        }
+      },
+
+      /**
+       * Create a new collection
+       */
+      createCollection: async (data: { name: string; description?: string; coverImage?: string; isPublic?: boolean }) => {
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+            body: JSON.stringify(data),
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            set((state) => ({
+              collections: [result.data, ...state.collections],
+            }));
+            return result.data;
+          }
+        } catch (error) {
+          console.error('Failed to create collection:', error);
+        }
+        return null;
+      },
+
+      /**
+       * Update collection
+       */
+      updateCollection: async (collectionId: string, data: Partial<{ name: string; description: string; coverImage: string; isPublic: boolean }>) => {
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections/${collectionId}`, {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+            body: JSON.stringify(data),
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            set((state) => ({
+              collections: state.collections.map((c: any) =>
+                c.id === collectionId ? { ...c, ...result.data } : c
+              ),
+            }));
+          }
+        } catch (error) {
+          console.error('Failed to update collection:', error);
+        }
+      },
+
+      /**
+       * Delete collection
+       */
+      deleteCollection: async (collectionId: string) => {
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections/${collectionId}`, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+
+          if (result.success) {
+            set((state) => ({
+              collections: state.collections.filter((c: any) => c.id !== collectionId),
+            }));
+          }
+        } catch (error) {
+          console.error('Failed to delete collection:', error);
+        }
+      },
+
+      /**
+       * Add artwork to collection
+       */
+      addToCollection: async (collectionId: string, artworkId: string) => {
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections/${collectionId}/artworks/${artworkId}`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+          return result.success;
+        } catch (error) {
+          console.error('Failed to add to collection:', error);
+          return false;
+        }
+      },
+
+      /**
+       * Remove artwork from collection
+       */
+      removeFromCollection: async (collectionId: string, artworkId: string) => {
+        try {
+          const response = await fetch(`${API_URL}/favorites/collections/${collectionId}/artworks/${artworkId}`, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user-id': localStorage.getItem('userId') || '',
+            },
+          });
+          const result = await response.json();
+          return result.success;
+        } catch (error) {
+          console.error('Failed to remove from collection:', error);
+          return false;
+        }
+      },
+
+      /**
+       * Clear current collection
+       */
+      clearCurrentCollection: () => {
+        set({ currentCollection: null });
+      },
+    }),
+    {
+      name: 'wuta-favorites-storage',
+      partialize: (state) => ({
+        // Only persist these fields
+        favorites: state.favorites,
+        favoriteIds: Array.from(state.favoriteIds),
+      }),
+      merge: (persisted: any, current) => ({
+        ...current,
+        ...persisted,
+        favoriteIds: new Set(persisted?.favoriteIds || []),
+      }),
+    }
+  )
+);
+
+export default useFavoritesStore;


### PR DESCRIPTION
Closes #159

---

Implemented artwork favorites and collections feature.

Heart button on artwork cards in Gallery and ArtworkGrid
New Favorites page with Favorites/Collections tabs
Create/edit/delete custom collections with public/private toggle
LocalStorage persistence for favorites
Added: Prisma models (Favorite, Collection, CollectionArtwork), backend API routes, Zustand store, FavoriteButton component, CollectionsManager modal, FavoritesPage.

Modified: ArtworkGrid.js, Gallery.js, App.js, routes/index.ts.