### PR TITLE
Enhance wallet error handling in useWalletStore and display error mes…

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -4,7 +4,7 @@ import { useWalletStore } from '../store/walletStore';
 
 const Settings = () => {
   const { theme, isDark, toggleTheme } = useTheme();
-  const { address, isConnected, connectWallet, disconnectWallet } = useWalletStore();
+  const { address, isConnected, connectWallet, disconnectWallet, error, errorMessage, clearError } = useWalletStore();
   const [autoSync, setAutoSync] = useState(false);
   const [subscriptionEmail, setSubscriptionEmail] = useState('');
   const [defaultBlockchain, setDefaultBlockchain] = useState('stellar');
@@ -52,6 +52,22 @@ const Settings = () => {
               </button>
             )}
           </div>
+          { (error || errorMessage) && (
+            <div className="mt-3 p-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <strong className="block">Wallet connection error</strong>
+                  <p className="text-sm mt-1">{(error && error.message) || errorMessage || 'An unknown error occurred while connecting your wallet.'}</p>
+                  {error && error.helpUrl && (
+                    <a href={error.helpUrl} target="_blank" rel="noreferrer" className="underline text-sm">Get help</a>
+                  )}
+                </div>
+                <div>
+                  <button onClick={clearError} className="px-3 py-1 rounded-md bg-gray-100 dark:bg-gray-800 text-sm">Dismiss</button>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="rounded-2xl bg-white dark:bg-gray-800 p-6 shadow-sm space-y-4">

--- a/src/store/walletStore.js
+++ b/src/store/walletStore.js
@@ -123,9 +123,59 @@ const useWalletStore = create(
 
     } catch (error) {
       console.error('Failed to connect wallet:', error);
+
+      // Map known errors to user-friendly messages and optional actions
+      const mapWalletError = (err) => {
+        const msg = String(err?.message || err || 'Unknown wallet error');
+
+        if (/Freighter wallet not found/i.test(msg)) {
+          return {
+            code: 'WALLET_NOT_FOUND',
+            message: 'Freighter wallet not found. Please install the Freighter extension or use a compatible wallet.',
+            action: 'install',
+            helpUrl: 'https://www.freighter.app/'
+          };
+        }
+
+        if (/user rejected|rejected request|denied/i.test(msg)) {
+          return {
+            code: 'USER_REJECTED',
+            message: 'Connection request was rejected in your wallet. Please approve the request to connect.',
+            action: 'retry'
+          };
+        }
+
+        if (/network|timeout|failed to fetch/i.test(msg)) {
+          return {
+            code: 'NETWORK_ERROR',
+            message: 'Network error while connecting to the wallet. Check your internet connection and try again.',
+            action: 'retry'
+          };
+        }
+
+        if (/public key|getPublicKey|Failed to retrieve public key/i.test(msg)) {
+          return {
+            code: 'NO_PUBLIC_KEY',
+            message: 'Failed to retrieve public key from the wallet. Ensure your wallet is unlocked and you granted permission.',
+            action: 'retry'
+          };
+        }
+
+        // Fallback generic message
+        return {
+          code: 'UNKNOWN_ERROR',
+          message: msg,
+          action: 'retry'
+        };
+      };
+
+      const structured = mapWalletError(error);
+
       set({
         isConnecting: false,
-        error: error.message
+        // Keep backwards compatibility by exposing both structured and plain message
+        error: structured,
+        errorMessage: structured.message
       });
     }
       },


### PR DESCRIPTION
closes #145 

Why: Users previously saw opaque, generic errors. Structured and actionable messages reduce confusion and speed up troubleshooting (install wallet, retry, unlock wallet, check network).